### PR TITLE
Flatten alpha on selection bg tokens before applying themes

### DIFF
--- a/lib/src/lib/themes/apply.ts
+++ b/lib/src/lib/themes/apply.ts
@@ -1,6 +1,7 @@
 import type { MouseTermTheme } from './types';
 import { getAllThemes, getStoredActiveThemeId, setActiveThemeId } from './store';
 import { completeThemeVars } from './vscode-color-resolver';
+import { flattenSelectionAlpha } from './flatten-alpha';
 
 let appliedThemeSnapshot: AppliedThemeSnapshot | null = null;
 
@@ -32,6 +33,12 @@ export function applyTheme(theme: MouseTermTheme): void {
   // them here so theme.css can read --vscode-* directly without fallbacks.
   const providedVars = { ...HOST_TYPOGRAPHY_VARS, ...theme.vars };
   const vars = completeThemeVars(providedVars, theme.type);
+  // Theme authors give list.*SelectionBackground alpha because VSCode renders
+  // it as an overlay on the sidebar. MouseTerm uses it as a solid AppBar /
+  // tab fill, so flatten the alpha over sideBar.background here — otherwise
+  // whatever sits behind the surface bleeds through (Selenized Dark's bright
+  // cyan AppBar, for instance).
+  flattenSelectionAlpha(vars);
   appliedThemeSnapshot = { theme, providedVars, resolvedVars: vars };
   for (const [name, value] of Object.entries(vars)) {
     document.body.style.setProperty(name, value);

--- a/lib/src/lib/themes/flatten-alpha.test.ts
+++ b/lib/src/lib/themes/flatten-alpha.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import { flattenAlpha, flattenSelectionAlpha } from './flatten-alpha';
+
+describe('flattenAlpha', () => {
+  it('returns the value unchanged when fully opaque', () => {
+    expect(flattenAlpha('#0096f5', '#0e4956')).toBe('#0096f5');
+    expect(flattenAlpha('#0096f5ff', '#0e4956')).toBe('#0096f5ff');
+  });
+
+  it('composites Selenized Dark selection (#0096f588) over its sidebar (#0e4956)', () => {
+    // 0x88 / 255 = 0.5333…
+    // r: 0x00*0.5333 + 0x0e*0.4667 ≈ 6.5  → 0x07
+    // g: 0x96*0.5333 + 0x49*0.4667 ≈ 114.0 → 0x72
+    // b: 0xf5*0.5333 + 0x56*0.4667 ≈ 170.7 → 0xab
+    expect(flattenAlpha('#0096f588', '#0e4956')).toBe('#0772ab');
+  });
+
+  it('handles 4-digit hex with alpha (short-hand expands per channel)', () => {
+    // #08f8 → rgba(0, 0x88=136, 255, 0x88/255=0.533); over white → #77c0ff
+    expect(flattenAlpha('#08f8', '#ffffff')).toBe('#77c0ff');
+  });
+
+  it('handles rgba() function syntax', () => {
+    expect(flattenAlpha('rgba(0, 0, 0, 0.5)', '#ffffff')).toBe('#808080');
+  });
+
+  it('falls back to the input when the base is unparseable', () => {
+    expect(flattenAlpha('#0096f588', 'oklab(0.5 0 0)')).toBe('#0096f588');
+  });
+});
+
+describe('flattenSelectionAlpha', () => {
+  it('flattens active and inactive selection backgrounds in place', () => {
+    const vars: Record<string, string> = {
+      '--vscode-sideBar-background': '#0e4956',
+      '--vscode-list-activeSelectionBackground': '#0096f588',
+      '--vscode-list-inactiveSelectionBackground': '#275b69',
+      '--vscode-editor-background': '#053d48',
+    };
+    flattenSelectionAlpha(vars);
+    expect(vars['--vscode-list-activeSelectionBackground']).toBe('#0772ab');
+    expect(vars['--vscode-list-inactiveSelectionBackground']).toBe('#275b69');
+    expect(vars['--vscode-editor-background']).toBe('#053d48');
+  });
+
+  it('is a no-op when sideBar background is missing', () => {
+    const vars: Record<string, string> = {
+      '--vscode-list-activeSelectionBackground': '#0096f588',
+    };
+    flattenSelectionAlpha(vars);
+    expect(vars['--vscode-list-activeSelectionBackground']).toBe('#0096f588');
+  });
+});

--- a/lib/src/lib/themes/flatten-alpha.ts
+++ b/lib/src/lib/themes/flatten-alpha.ts
@@ -1,0 +1,77 @@
+/* Composite a translucent CSS color over an opaque base, returning an opaque
+ * hex result. Used to flatten VSCode tokens that carry alpha (e.g. Selenized
+ * Dark's list.activeSelectionBackground = #0096f588) when MouseTerm applies
+ * them as solid surface fills — the AppBar, dockview tabs, etc. all expect a
+ * fully opaque color, but VSCode authors selection tints with alpha because
+ * VSCode itself renders them as overlays on the sidebar background. */
+
+interface Rgba { r: number; g: number; b: number; a: number }
+
+const HEX_SHORT = /^#([0-9a-f])([0-9a-f])([0-9a-f])([0-9a-f])?$/i;
+const HEX_LONG = /^#([0-9a-f]{2})([0-9a-f]{2})([0-9a-f]{2})([0-9a-f]{2})?$/i;
+const RGB_FN = /^rgba?\(\s*([0-9.]+)\s*[, ]\s*([0-9.]+)\s*[, ]\s*([0-9.]+)(?:\s*[,/]\s*([0-9.]+%?))?\s*\)$/i;
+
+function parseColor(value: string): Rgba | null {
+  const v = value.trim();
+
+  let m = HEX_SHORT.exec(v);
+  if (m) {
+    const dup = (h: string) => parseInt(h + h, 16);
+    return { r: dup(m[1]), g: dup(m[2]), b: dup(m[3]), a: m[4] ? dup(m[4]) / 255 : 1 };
+  }
+
+  m = HEX_LONG.exec(v);
+  if (m) {
+    return {
+      r: parseInt(m[1], 16),
+      g: parseInt(m[2], 16),
+      b: parseInt(m[3], 16),
+      a: m[4] ? parseInt(m[4], 16) / 255 : 1,
+    };
+  }
+
+  m = RGB_FN.exec(v);
+  if (m) {
+    const a = m[4] ? (m[4].endsWith('%') ? parseFloat(m[4]) / 100 : parseFloat(m[4])) : 1;
+    return { r: parseFloat(m[1]), g: parseFloat(m[2]), b: parseFloat(m[3]), a };
+  }
+
+  return null;
+}
+
+function toHex({ r, g, b }: Rgba): string {
+  const h = (n: number) => Math.max(0, Math.min(255, Math.round(n))).toString(16).padStart(2, '0');
+  return `#${h(r)}${h(g)}${h(b)}`;
+}
+
+/** Composite `value` over `base`. If `value` has no alpha, it's returned
+ *  unchanged. If either color can't be parsed, returns `value` as-is. */
+export function flattenAlpha(value: string, base: string): string {
+  const fg = parseColor(value);
+  if (!fg || fg.a >= 1) return value;
+  const bg = parseColor(base);
+  if (!bg) return value;
+  return toHex({
+    r: fg.r * fg.a + bg.r * (1 - fg.a),
+    g: fg.g * fg.a + bg.g * (1 - fg.a),
+    b: fg.b * fg.a + bg.b * (1 - fg.a),
+    a: 1,
+  });
+}
+
+/* VSCode tokens that MouseTerm uses as solid surface fills but whose theme
+ * authors commonly carry alpha. Flattened against sideBar.background — the
+ * surface VSCode itself composites the file-tree selection over. */
+const FLATTEN_OVER_SIDEBAR: readonly string[] = [
+  '--vscode-list-activeSelectionBackground',
+  '--vscode-list-inactiveSelectionBackground',
+];
+
+export function flattenSelectionAlpha(vars: Record<string, string>): void {
+  const base = vars['--vscode-sideBar-background'];
+  if (!base) return;
+  for (const name of FLATTEN_OVER_SIDEBAR) {
+    const v = vars[name];
+    if (v) vars[name] = flattenAlpha(v, base);
+  }
+}


### PR DESCRIPTION
## Summary
- Some themes (Selenized Dark, Solarized Dark, Selenized Light, Solarized Light) ship `list.activeSelectionBackground` with alpha (e.g. `#0096f588`) because VSCode renders it as an overlay on the sidebar. MouseTerm uses the same token as a solid AppBar / tab fill, so whatever sat behind the surface bled through — on macOS that produced a bright cyan AppBar in focused state.
- New `flatten-alpha.ts` helper composites `list.{active,inactive}SelectionBackground` over `sideBar.background` (the surface VSCode itself overlays them on) inside `applyTheme`, so the materialized `--vscode-*` vars are opaque and match what VSCode shows in the file tree. Original alpha values are preserved on `theme.vars` and the snapshot's `providedVars` for diagnostics.

## Test plan
- [x] `pnpm vitest run` (304 tests pass, including 7 new `flatten-alpha` tests covering opaque passthrough, short/long hex, rgba(), unparseable input, and the actual Selenized Dark case)
- [x] `pnpm tsc --noEmit` clean
- [x] Visually verify focused AppBar in Selenized Dark / Solarized Dark / Selenized Light / Solarized Light no longer flashes the underlying chrome through translucent selection color
- [x] Confirm dockview tabs / `TerminalPaneHeader` / `TodoAlertDialog` still look correct in non-affected themes (Default Dark+, Monokai, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)