### PR TITLE
Disable Tauri OS drag-drop so panes can be rearranged in standalone

### DIFF
--- a/lib/src/components/wall/use-session-persistence.ts
+++ b/lib/src/components/wall/use-session-persistence.ts
@@ -97,6 +97,7 @@ export function useSessionPersistence({
     platform.onRequestSessionFlush(handleSessionFlushRequest);
     window.addEventListener('pagehide', handlePageHide);
 
+    // Inert in Tauri standalone today; see diffplug/mouseterm#38 and tauri-apps/tauri#14373.
     const unsubFilesDropped = platform.onFilesDropped?.((paths) => {
       if (paths.length === 0) return;
       const sid = selectedTypeRef.current === 'pane' ? selectedIdRef.current : null;

--- a/lib/src/lib/platform/types.ts
+++ b/lib/src/lib/platform/types.ts
@@ -29,7 +29,7 @@ export interface PlatformAdapter {
   // Clipboard support for file references and raw images.
   readClipboardFilePaths(): Promise<string[] | null>;
   readClipboardImageAsFilePath(): Promise<string | null>;
-  // Only present on adapters with a native (non-DOM) drag-drop source.
+  // Only present on adapters with a native (non-DOM) drag-drop source. Currently inert in Tauri; see diffplug/mouseterm#38 and tauri-apps/tauri#14373.
   onFilesDropped?(handler: (paths: string[]) => void): () => void;
 
   // PTY event listeners

--- a/standalone/src-tauri/src/lib.rs
+++ b/standalone/src-tauri/src/lib.rs
@@ -508,6 +508,7 @@ pub fn run() {
             let refs: Vec<&dyn tauri::menu::IsMenuItem<_>> = items.iter().map(|b| b.as_ref()).collect();
             Menu::with_items(handle, &refs)
         })
+        // Inert while tauri.conf.json sets dragDropEnabled=false (needed for HTML5 pane drag). See diffplug/mouseterm#38 and tauri-apps/tauri#14373.
         .on_window_event(|window, event| {
             if let WindowEvent::DragDrop(DragDropEvent::Drop { paths, .. }) = event {
                 let payload: Vec<String> = paths

--- a/standalone/src-tauri/tauri.conf.json
+++ b/standalone/src-tauri/tauri.conf.json
@@ -17,7 +17,8 @@
         "hiddenTitle": true,
         "width": 1200,
         "height": 800,
-        "resizable": true
+        "resizable": true,
+        "dragDropEnabled": false
       }
     ],
     "security": {

--- a/standalone/src/tauri-adapter.ts
+++ b/standalone/src/tauri-adapter.ts
@@ -78,6 +78,7 @@ export class TauriAdapter implements PlatformAdapter {
       }),
     );
 
+    // Inert while dragDropEnabled=false in tauri.conf.json. See diffplug/mouseterm#38 and tauri-apps/tauri#14373.
     this.unlistenFns.push(
       await listen<{ paths: string[] }>("mouseterm://files-dropped", (event) => {
         const paths = event.payload.paths ?? [];


### PR DESCRIPTION
## Summary

- Sets `dragDropEnabled: false` on the standalone window so HTML5 drag events flow to the webview, restoring Dockview pane rearrangement (which was broken in the standalone build).
- The OS-level file-drop-to-paste path goes inert as a side effect; existing Rust + TS wiring is kept as stubs so re-enabling later is a small change.
- Adds one-line comments at each stub site referencing #38 and tauri-apps/tauri#14373.

Closes nothing — tracked at #38, blocked on tauri-apps/tauri#14373.

## Test plan

- [x] `pnpm dev:standalone` launches cleanly.
- [x] Pane drag-to-rearrange works in the standalone (verified manually).
- [x] File drop into a pane is intentionally a no-op (per #38).
- [x] No regression in the VS Code extension (the `onFilesDropped` interface method stays optional and the VS Code adapter never implemented it, so behavior there is unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)