### PR TITLE
Apply login-shell -l flag when args array is empty

### DIFF
--- a/standalone/sidecar/pty-core.js
+++ b/standalone/sidecar/pty-core.js
@@ -63,7 +63,11 @@ function resolveSpawnConfig(options, runtime = {}) {
   const defaultCwd = resolveDefaultCwd(platform, env, osModule);
   const missingExplicitCwd = Boolean(cwd) && !directoryExists(cwd, fsModule);
   const shell = explicitShell || resolveDefaultShell(platform, env);
-  const shellArgs = explicitArgs || resolveLoginArg(shell, platform);
+  // An empty array means "no override," not "no args" — fall through to the
+  // login-flag default so `~/.zprofile` runs and PATH includes Homebrew/asdf.
+  const shellArgs = explicitArgs && explicitArgs.length > 0
+    ? explicitArgs
+    : resolveLoginArg(shell, platform);
 
   return {
     cols,

--- a/standalone/sidecar/pty-core.test.js
+++ b/standalone/sidecar/pty-core.test.js
@@ -100,6 +100,27 @@ test('resolveSpawnConfig falls back to the default directory when explicit cwd i
   assert.equal(config.rows, 40);
 });
 
+test('resolveSpawnConfig treats empty args array as no-override and applies -l', () => {
+  // Regression: detectAvailableShells returns args:[] on Unix, which used to
+  // suppress the -l fallback (empty array is truthy). That caused the login
+  // shell to skip ~/.zprofile, leaving Homebrew/asdf off PATH and producing
+  // "asdf_update_java_home: command not found: asdf" on every prompt.
+  const config = resolveSpawnConfig(
+    { args: [] },
+    {
+      platform: 'darwin',
+      env: { SHELL: '/bin/zsh' },
+      osModule: {
+        homedir: () => '/Users/tester',
+        tmpdir: () => '/tmp/fallback',
+      },
+    },
+  );
+
+  assert.equal(config.shell, '/bin/zsh');
+  assert.deepEqual(config.shellArgs, ['-l']);
+});
+
 test('resolveSpawnConfig skips -l for csh', () => {
   const config = resolveSpawnConfig(undefined, {
     platform: 'darwin',
@@ -223,21 +244,20 @@ test('resolveSpawnConfig uses explicit shell with default args fallback', () => 
   assert.deepEqual(config.shellArgs, ['-l']);
 });
 
-test('resolveSpawnConfig uses explicit args with empty array', () => {
+test('resolveSpawnConfig honors non-empty explicit args (e.g. WSL distro flags)', () => {
   const config = resolveSpawnConfig(
-    { args: [] },
+    { args: ['-d', 'Ubuntu'] },
     {
-      platform: 'linux',
-      env: { SHELL: '/bin/bash' },
+      platform: 'win32',
+      env: {},
       osModule: {
-        homedir: () => '/home/tester',
-        tmpdir: () => '/tmp/fallback',
+        homedir: () => 'C:\\Users\\tester',
+        tmpdir: () => 'C:\\Temp',
       },
     },
   );
 
-  assert.equal(config.shell, '/bin/bash');
-  assert.deepEqual(config.shellArgs, []);
+  assert.deepEqual(config.shellArgs, ['-d', 'Ubuntu']);
 });
 
 // ── detectAvailableShells ───────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- `resolveSpawnConfig` used `explicitArgs || resolveLoginArg(...)`. Empty arrays are truthy in JS, so an `args: []` from `detectAvailableShells` (the default on Unix) suppressed the `-l` fallback and the shell launched without login mode.
- On standalone macOS this skipped `~/.zprofile`, so `eval "$(brew shellenv)"` never ran and `/opt/homebrew/bin` was missing from PATH. `~/.zshrc` still loaded asdf's java plugin, and its precmd hook printed `asdf_update_java_home:2: command not found: asdf` on every prompt.
- VS Code hid the bug because the extension host inherits a fully resolved login-shell env at startup, so the spawned shell got Homebrew on PATH even without `-l`.
- Fix: treat an empty `args` array as "no override" and fall through to `resolveLoginArg`. Updated the test that pinned the buggy behavior; added a regression test for the macOS/zsh case and one that confirms non-empty explicit args (e.g. WSL `-d <distro>`) still pass through unchanged.

## Test plan
- [x] `node --test standalone/sidecar/pty-core.test.js` — 18/18 pass
- [x] Build the standalone macOS app from this branch, launch from Finder, confirm fresh prompts no longer print `asdf_update_java_home:2: command not found: asdf`
- [x] Confirm `echo $PATH` inside a standalone terminal includes `/opt/homebrew/bin` and the asdf shims directory
- [x] Smoke test the VS Code extension to make sure shell spawn behavior is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)