### PR TITLE
Require approval before downloading updates and use versioned changelog links

### DIFF
--- a/docs/specs/auto-update.md
+++ b/docs/specs/auto-update.md
@@ -1,6 +1,6 @@
 # Auto-Update Spec
 
-The standalone app checks for updates on launch, downloads silently in the background, and installs when the user quits. A banner tells the user an update is pending. On next launch, a brief banner confirms the update succeeded (or notes a failure).
+The standalone app checks for updates on launch and prompts in the Baseboard when one is available. It does not download or install the update until the user approves the prompt. Once approved, the app downloads the update in the background and installs it when the user quits. On next launch, a brief banner confirms the update succeeded (or notes a failure).
 
 ## How it works
 
@@ -9,40 +9,48 @@ app launch
   │
   ├─ check for post-install markers in localStorage
   │    ├─ success marker → show "Updated to vX.Y.Z" banner (auto-dismisses after 10s)
-  │    ├─ failure marker → show "Update failed — will retry" banner
+  │    ├─ failure marker → show "Update failed." banner with debug action
   │    └─ no marker → continue
   │
   ├─ wait 5 seconds
   │
   ├─ check(endpoint) ──→ no update ──→ done (silent)
   │                  │
-  │                  └─→ update available → download in background
-  │                                           ├─ success → show "will install when you quit" banner
-  │                                           └─ failure → log error, done (silent)
+  │                  └─→ update available → show approval prompt
+  │                                           │
+  │                                           ├─ dismissed/no approval → no download, no install
+  │                                           │
+  │                                           └─ user approves → download in background
+  │                                                              ├─ success → show "will install when you quit" banner
+  │                                                              └─ failure → log error, return to approval prompt
   │
   ... user works normally ...
   │
   user quits
   │
-  ├─ no pending update → exit normally
-  └─ pending update → write success marker → install() → exit
+  ├─ no approved, downloaded update → exit normally
+  └─ approved, downloaded update → write success marker → install() → exit
                          │
                          └─ install fails → overwrite with failure marker → exit normally
 ```
 
-The `Update` object from `download()` is held in memory for the session. The close handler intercepts the window close event, writes a success marker to `localStorage` *before* calling `install()` (because on Windows, NSIS force-kills the process), then calls `install()`. In Vite dev mode (`pnpm dev:standalone`), the close handler skips `install()` without preventing the close. Dev mode is useful for testing check/download/banner behavior, but install must be tested from a packaged app because the updater resolves its replacement target from the current executable path.
+The `Update` object returned by `check()` is held in memory as an available update. Clicking the approval action calls `download()` and promotes it to a pending update only after the download succeeds. The close handler intercepts the window close event only when there is an approved, downloaded update, writes a success marker to `localStorage` *before* calling `install()` (because on Windows, NSIS force-kills the process), then calls `install()`. In Vite dev mode (`pnpm dev:standalone`), the close handler skips `install()` without preventing the close. Dev mode is useful for testing check/download/banner behavior, but install must be tested from a packaged app because the updater resolves its replacement target from the current executable path.
 
 ## Update notice in the Baseboard
 
 Update status appears as a text notice on the right side of the Baseboard (the always-visible bottom strip — see `layout.md`). It coexists with doors and shortcut hints.
 
-| State | Message | Changelog | Auto-dismiss |
-|-------|---------|-----------|--------------|
-| `downloaded` | "Update downloaded (v0.5.0) — will install when you quit." | Yes | No |
-| `post-update-success` | "Updated to v0.5.0 — from v0.4.0." | Yes | 10 seconds |
-| `post-update-failure` | "Update to v0.5.0 failed — will retry next launch." | No | No |
+| State | Message | Actions | Auto-dismiss |
+|-------|---------|---------|--------------|
+| `available` | "Update available (v0.5.0)." | "Install on quit", "Changelog" | No |
+| `downloading` | "Downloading update (v0.5.0)..." | "Changelog" | No |
+| `downloaded` | "Update downloaded (v0.5.0) — will install when you quit." | "Changelog" | No |
+| `post-update-success` | "Updated to v0.5.0 — from v0.4.0." | "Changelog" | 10 seconds |
+| `post-update-failure` | "Update failed." | "Click here to debug" | No |
 
-All states are dismissible via [×]. Dismissing hides the notice for the session only — it does not affect whether the update installs on quit.
+The "Install on quit" action is the user's approval to download the update now and install it when they quit.
+
+All states are dismissible via [×]. Dismissing an unapproved `available` notice means no update is downloaded or installed in that session. Dismissing a `downloading` or `downloaded` notice hides it for the session only — it does not cancel an already-approved download/install.
 
 The notice matches the Baseboard's existing text style (9px mono, `text-muted`). It's pushed right via `ml-auto` so it doesn't compete with doors or the shortcut hint on the left.
 
@@ -70,13 +78,13 @@ Single key: `mouseterm:update-result`
 | Successful install | `{ "from": "0.4.0", "to": "0.5.0" }` | On next launch, after reading |
 | Failed install | `{ "failed": true, "version": "0.5.0", "error": "..." }` | On next launch, after reading |
 
-The success marker is written *before* `install()` because Windows NSIS force-kills the process — if we wrote it after, it would never persist. If `install()` then throws, the marker is overwritten with a failure entry.
+The success marker is written *before* `install()` because Windows NSIS force-kills the process — if we wrote it after, it would never persist. If `install()` then throws, the marker is overwritten with a failure entry. No marker is written for an update that was found but never approved.
 
 ## Files
 
 | File | Role |
 |------|------|
-| [`standalone/src/updater.ts`](../../standalone/src/updater.ts) | State machine, update check, background download, close handler, post-install markers |
+| [`standalone/src/updater.ts`](../../standalone/src/updater.ts) | State machine, update check, user-approved download, close handler, post-install markers |
 | [`standalone/src/UpdateBanner.tsx`](../../standalone/src/UpdateBanner.tsx) | Pure presentational component — renders inline notice content for the Baseboard |
 | [`standalone/src/main.tsx`](../../standalone/src/main.tsx) | Passes `<ConnectedUpdateBanner />` as the `baseboardNotice` prop to `<App />`, calls `startUpdateCheck()` after platform init |
 
@@ -108,9 +116,9 @@ The Rust side registers the plugin with `tauri_plugin_updater::Builder::new().bu
 
 ## Design decisions
 
-**Why install on quit, not on demand?** MouseTerm is a terminal app with running processes. A mid-session relaunch would kill all sessions. By installing at quit time, the user has already decided to close their terminals.
+**Why install on quit after approval, not immediately?** MouseTerm is a terminal app with running processes. A mid-session relaunch would kill all sessions. By installing at quit time, the user has already decided to close their terminals.
 
-**Why no "skip this version"?** The update is already downloaded and will install on quit regardless. There's nothing to opt out of. [×] just hides the notification.
+**Why no silent download?** Update bundles can be large, can fail for environment-specific reasons, and may surprise users who did not opt into changing the app. The launch probe is silent, but download/install only begins after explicit approval.
 
 **Why the Baseboard, not a top banner?** A top banner pushes terminal content down, which is disruptive in a terminal app. The Baseboard is already a status strip — the update notice fits naturally alongside doors and shortcut hints. It also avoids adding a new UI element; the notice just occupies unused space in an existing one.
 

--- a/docs/specs/auto-update.md
+++ b/docs/specs/auto-update.md
@@ -48,7 +48,7 @@ Update status appears as a text notice on the right side of the Baseboard (the a
 | `post-update-success` | "Updated to v0.5.0 — from v0.4.0." | "Changelog" | 10 seconds |
 | `post-update-failure` | "Update failed." | "Click here to debug" | No |
 
-The "Install on quit" action is the user's approval to download the update now and install it when they quit.
+The "Install on quit" action is the user's approval to download the update now and install it when they quit. Changelog actions open `https://mouseterm.com/changelog/after/<current-version>` using the current app version returned by Tauri. If the version cannot be read, the action falls back to `https://mouseterm.com/changelog`.
 
 All states are dismissible via [×]. Dismissing an unapproved `available` notice means no update is downloaded or installed in that session. Dismissing a `downloading` or `downloaded` notice hides it for the session only — it does not cancel an already-approved download/install.
 

--- a/docs/specs/auto-update.md
+++ b/docs/specs/auto-update.md
@@ -42,13 +42,13 @@ Update status appears as a text notice on the right side of the Baseboard (the a
 
 | State | Message | Actions | Auto-dismiss |
 |-------|---------|---------|--------------|
-| `available` | "Update available (v0.5.0)." | "Install on quit", "Changelog" | No |
+| `available` | "Update available" | "Changelog", "Install when I quit" | No |
 | `downloading` | "Downloading update (v0.5.0)..." | "Changelog" | No |
 | `downloaded` | "Update downloaded (v0.5.0) — will install when you quit." | "Changelog" | No |
 | `post-update-success` | "Updated to v0.5.0 — from v0.4.0." | "Changelog" | 10 seconds |
 | `post-update-failure` | "Update failed." | "Click here to debug" | No |
 
-The "Install on quit" action is the user's approval to download the update now and install it when they quit. Changelog actions call Tauri's `getVersion()` and open `https://mouseterm.com/changelog/after/<current-version>`.
+The "Install when I quit" action is the user's approval to download the update now and install it when they quit. The inline "Changelog" action calls Tauri's `getVersion()` and opens `https://mouseterm.com/changelog/after/<current-version>`.
 
 All states are dismissible via [×]. Dismissing an unapproved `available` notice means no update is downloaded or installed in that session. Dismissing a `downloading` or `downloaded` notice hides it for the session only — it does not cancel an already-approved download/install.
 

--- a/docs/specs/auto-update.md
+++ b/docs/specs/auto-update.md
@@ -48,7 +48,7 @@ Update status appears as a text notice on the right side of the Baseboard (the a
 | `post-update-success` | "Updated to v0.5.0 — from v0.4.0." | "Changelog" | 10 seconds |
 | `post-update-failure` | "Update failed." | "Click here to debug" | No |
 
-The "Install on quit" action is the user's approval to download the update now and install it when they quit. Changelog actions open `https://mouseterm.com/changelog/after/<current-version>` using the current app version returned by Tauri. If the version cannot be read, the action falls back to `https://mouseterm.com/changelog`.
+The "Install on quit" action is the user's approval to download the update now and install it when they quit. Changelog actions call Tauri's `getVersion()` and open `https://mouseterm.com/changelog/after/<current-version>`.
 
 All states are dismissible via [×]. Dismissing an unapproved `available` notice means no update is downloaded or installed in that session. Dismissing a `downloading` or `downloaded` notice hides it for the session only — it does not cancel an already-approved download/install.
 

--- a/docs/specs/auto-update.md
+++ b/docs/specs/auto-update.md
@@ -43,12 +43,13 @@ Update status appears as a text notice on the right side of the Baseboard (the a
 | State | Message | Actions | Auto-dismiss |
 |-------|---------|---------|--------------|
 | `available` | "Update available" | "Changelog", "Install when I quit" | No |
-| `downloading` | "Downloading update (v0.5.0)..." | "Changelog" | No |
-| `downloaded` | "Update downloaded (v0.5.0) — will install when you quit." | "Changelog" | No |
-| `post-update-success` | "Updated to v0.5.0 — from v0.4.0." | "Changelog" | 10 seconds |
-| `post-update-failure` | "Update failed." | "Click here to debug" | No |
+| `downloading` | "Downloading update v0.5.0" | "Changelog" | No |
+| `downloaded` | "Update downloaded (v0.5.0) — will install when you quit" | "Changelog" | No |
+| `post-update-success` | "Updated to v0.5.0 — from v0.4.0" | "Changelog" | 10 seconds |
+| `post-update-failure` | "Update failed" | "Click here to debug" | No |
 
 The "Install when I quit" action is the user's approval to download the update now and install it when they quit. The inline "Changelog" action calls Tauri's `getVersion()` and opens `https://mouseterm.com/changelog/after/<current-version>`.
+When a notice has follow-up actions, it uses ` · ` as the separator between the message and action labels.
 
 All states are dismissible via [×]. Dismissing an unapproved `available` notice means no update is downloaded or installed in that session. Dismissing a `downloading` or `downloaded` notice hides it for the session only — it does not cancel an already-approved download/install.
 

--- a/lib/src/stories/UpdateBanner.stories.tsx
+++ b/lib/src/stories/UpdateBanner.stories.tsx
@@ -7,6 +7,7 @@ function UpdateBannerStory({ state, expectedNullReason }: { state: UpdateBannerS
       <UpdateBanner
         state={state}
         onDismiss={() => console.log('Dismiss')}
+        onApproveUpdate={() => console.log('Approve update')}
         onOpenChangelog={() => console.log('Open changelog')}
         onOpenDebug={() => console.log('Open debug')}
       />
@@ -26,6 +27,18 @@ const meta: Meta<typeof UpdateBannerStory> = {
 
 export default meta;
 type Story = StoryObj<typeof UpdateBannerStory>;
+
+export const Available: Story = {
+  args: {
+    state: { status: 'available', version: '0.5.0' },
+  },
+};
+
+export const Downloading: Story = {
+  args: {
+    state: { status: 'downloading', version: '0.5.0' },
+  },
+};
 
 export const Downloaded: Story = {
   args: {

--- a/lib/src/stories/UpdateBanner.stories.tsx
+++ b/lib/src/stories/UpdateBanner.stories.tsx
@@ -7,7 +7,7 @@ function UpdateBannerStory({ state, expectedNullReason }: { state: UpdateBannerS
       <UpdateBanner
         state={state}
         onDismiss={() => console.log('Dismiss')}
-        onApproveUpdate={() => console.log('Install on quit')}
+        onApproveUpdate={() => console.log('Install when I quit')}
         onOpenChangelog={() => console.log('Open changelog')}
         onOpenDebug={() => console.log('Open debug')}
       />

--- a/lib/src/stories/UpdateBanner.stories.tsx
+++ b/lib/src/stories/UpdateBanner.stories.tsx
@@ -7,7 +7,7 @@ function UpdateBannerStory({ state, expectedNullReason }: { state: UpdateBannerS
       <UpdateBanner
         state={state}
         onDismiss={() => console.log('Dismiss')}
-        onApproveUpdate={() => console.log('Approve update')}
+        onApproveUpdate={() => console.log('Install on quit')}
         onOpenChangelog={() => console.log('Open changelog')}
         onOpenDebug={() => console.log('Open debug')}
       />
@@ -74,7 +74,7 @@ export const Dismissed: Story = {
 
 export const NarrowViewport: Story = {
   args: {
-    state: { status: 'downloaded', version: '0.5.0' },
+    state: { status: 'available', version: '0.5.0' },
   },
   decorators: [
     (Story) => (

--- a/standalone/src/UpdateBanner.tsx
+++ b/standalone/src/UpdateBanner.tsx
@@ -45,19 +45,19 @@ export function UpdateBanner({ state, onDismiss, onApproveUpdate, onOpenChangelo
       links = [];
       break;
     case 'downloading':
-      message = `Downloading update (v${state.version})...`;
+      message = `Downloading update v${state.version}`;
       links = [{ label: 'Changelog', onClick: onOpenChangelog }];
       break;
     case 'downloaded':
-      message = `Update downloaded (v${state.version}) — will install when you quit.`;
+      message = `Update downloaded (v${state.version}) — will install when you quit`;
       links = [{ label: 'Changelog', onClick: onOpenChangelog }];
       break;
     case 'post-update-success':
-      message = `Updated to v${state.to} — from v${state.from}.`;
+      message = `Updated to v${state.to} — from v${state.from}`;
       links = [{ label: 'Changelog', onClick: onOpenChangelog }];
       break;
     case 'post-update-failure':
-      message = 'Update failed.';
+      message = 'Update failed';
       links = [{ label: 'Click here to debug', onClick: onOpenDebug }];
       break;
     default: {
@@ -70,9 +70,12 @@ export function UpdateBanner({ state, onDismiss, onApproveUpdate, onOpenChangelo
     <span className="flex items-center gap-1.5 pb-1 text-sm font-mono text-muted">
       <span className="truncate">{message}</span>
       {links.map((link) => (
-        <button key={link.label} onClick={link.onClick} className={linkClass} style={linkStyle}>
-          {link.label}
-        </button>
+        <span key={link.label} className="contents">
+          <span className="shrink-0">·</span>
+          <button onClick={link.onClick} className={linkClass} style={linkStyle}>
+            {link.label}
+          </button>
+        </span>
       ))}
       <button
         onClick={onDismiss}

--- a/standalone/src/UpdateBanner.tsx
+++ b/standalone/src/UpdateBanner.tsx
@@ -2,6 +2,8 @@ import { XIcon } from '@phosphor-icons/react';
 
 export type UpdateBannerState =
   | { status: 'idle' }
+  | { status: 'available'; version: string }
+  | { status: 'downloading'; version: string }
   | { status: 'downloaded'; version: string }
   | { status: 'dismissed' }
   | { status: 'post-update-success'; from: string; to: string }
@@ -10,6 +12,7 @@ export type UpdateBannerState =
 interface UpdateBannerProps {
   state: UpdateBannerState;
   onDismiss: () => void;
+  onApproveUpdate: () => void;
   onOpenChangelog: () => void;
   onOpenDebug: () => void;
 }
@@ -17,24 +20,35 @@ interface UpdateBannerProps {
 const linkClass = 'shrink-0 hover:underline';
 const linkStyle = { color: 'var(--vscode-textLink-foreground)' };
 
-export function UpdateBanner({ state, onDismiss, onOpenChangelog, onOpenDebug }: UpdateBannerProps) {
+export function UpdateBanner({ state, onDismiss, onApproveUpdate, onOpenChangelog, onOpenDebug }: UpdateBannerProps) {
   if (state.status === 'idle' || state.status === 'dismissed') return null;
 
   let message: string;
-  let link: { label: string; onClick: () => void };
+  let links: { label: string; onClick: () => void }[];
 
   switch (state.status) {
+    case 'available':
+      message = `Update available (v${state.version}).`;
+      links = [
+        { label: 'Install on quit', onClick: onApproveUpdate },
+        { label: 'Changelog', onClick: onOpenChangelog },
+      ];
+      break;
+    case 'downloading':
+      message = `Downloading update (v${state.version})...`;
+      links = [{ label: 'Changelog', onClick: onOpenChangelog }];
+      break;
     case 'downloaded':
       message = `Update downloaded (v${state.version}) — will install when you quit.`;
-      link = { label: 'Changelog', onClick: onOpenChangelog };
+      links = [{ label: 'Changelog', onClick: onOpenChangelog }];
       break;
     case 'post-update-success':
       message = `Updated to v${state.to} — from v${state.from}.`;
-      link = { label: 'Changelog', onClick: onOpenChangelog };
+      links = [{ label: 'Changelog', onClick: onOpenChangelog }];
       break;
     case 'post-update-failure':
       message = 'Update failed.';
-      link = { label: 'Click here to debug', onClick: onOpenDebug };
+      links = [{ label: 'Click here to debug', onClick: onOpenDebug }];
       break;
     default: {
       const _exhaustive: never = state;
@@ -45,9 +59,11 @@ export function UpdateBanner({ state, onDismiss, onOpenChangelog, onOpenDebug }:
   return (
     <span className="flex items-center gap-1.5 pb-1 text-sm font-mono text-muted">
       <span className="truncate">{message}</span>
-      <button onClick={link.onClick} className={linkClass} style={linkStyle}>
-        {link.label}
-      </button>
+      {links.map((link) => (
+        <button key={link.label} onClick={link.onClick} className={linkClass} style={linkStyle}>
+          {link.label}
+        </button>
+      ))}
       <button
         onClick={onDismiss}
         className="shrink-0 rounded p-0.5 hover:bg-foreground/10 hover:text-foreground"

--- a/standalone/src/UpdateBanner.tsx
+++ b/standalone/src/UpdateBanner.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from 'react';
 import { XIcon } from '@phosphor-icons/react';
 
 export type UpdateBannerState =
@@ -23,16 +24,25 @@ const linkStyle = { color: 'var(--vscode-textLink-foreground)' };
 export function UpdateBanner({ state, onDismiss, onApproveUpdate, onOpenChangelog, onOpenDebug }: UpdateBannerProps) {
   if (state.status === 'idle' || state.status === 'dismissed') return null;
 
-  let message: string;
+  let message: ReactNode;
   let links: { label: string; onClick: () => void }[];
 
   switch (state.status) {
     case 'available':
-      message = `Update available (v${state.version}).`;
-      links = [
-        { label: 'Install on quit', onClick: onApproveUpdate },
-        { label: 'Changelog', onClick: onOpenChangelog },
-      ];
+      message = (
+        <>
+          Update available
+          {' · '}
+          <button onClick={onOpenChangelog} className={linkClass} style={linkStyle}>
+            Changelog
+          </button>
+          {' · '}
+          <button onClick={onApproveUpdate} className={linkClass} style={linkStyle}>
+            Install when I quit
+          </button>
+        </>
+      );
+      links = [];
       break;
     case 'downloading':
       message = `Downloading update (v${state.version})...`;

--- a/standalone/src/main.tsx
+++ b/standalone/src/main.tsx
@@ -15,6 +15,7 @@ import {
   startUpdateCheck,
   useUpdateState,
   dismissBanner,
+  approveUpdate,
   openChangelog,
   buildDebugReport,
 } from "./updater";
@@ -46,6 +47,7 @@ function ConnectedUpdateBanner() {
       <UpdateBanner
         state={state}
         onDismiss={dismissBanner}
+        onApproveUpdate={approveUpdate}
         onOpenChangelog={openChangelog}
         onOpenDebug={() => {
           if (liveFailure) {

--- a/standalone/src/updater.test.ts
+++ b/standalone/src/updater.test.ts
@@ -47,7 +47,13 @@ function makeUpdate(version = '0.5.0') {
 }
 
 // Import after mocks
-import { startUpdateCheck, openChangelog, buildDebugReport, _resetForTesting } from './updater';
+import {
+  startUpdateCheck,
+  approveUpdate,
+  openChangelog,
+  buildDebugReport,
+  _resetForTesting,
+} from './updater';
 
 describe('updater', () => {
   beforeEach(() => {
@@ -120,13 +126,17 @@ describe('updater', () => {
       expect(mocks.check).toHaveBeenCalledOnce();
     });
 
-    it('downloads when an update is available', async () => {
+    it('does not download until the user approves the update', async () => {
       const update = makeUpdate();
       mocks.check.mockResolvedValue(update);
 
       startUpdateCheck();
       await vi.advanceTimersByTimeAsync(5_000);
-      // Let check() and download() resolve
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(update.download).not.toHaveBeenCalled();
+
+      approveUpdate();
       await vi.advanceTimersByTimeAsync(0);
 
       expect(update.download).toHaveBeenCalledOnce();
@@ -151,6 +161,8 @@ describe('updater', () => {
       startUpdateCheck();
       await vi.advanceTimersByTimeAsync(5_000);
       await vi.advanceTimersByTimeAsync(0);
+      approveUpdate();
+      await vi.advanceTimersByTimeAsync(0);
 
       expect(update.download).toHaveBeenCalledOnce();
     });
@@ -171,6 +183,8 @@ describe('updater', () => {
 
       startUpdateCheck();
       await vi.advanceTimersByTimeAsync(5_000);
+      await vi.advanceTimersByTimeAsync(0);
+      approveUpdate();
       await vi.advanceTimersByTimeAsync(0);
 
       // Get the close handler
@@ -201,6 +215,8 @@ describe('updater', () => {
       startUpdateCheck();
       await vi.advanceTimersByTimeAsync(5_000);
       await vi.advanceTimersByTimeAsync(0);
+      approveUpdate();
+      await vi.advanceTimersByTimeAsync(0);
 
       const closeHandler = mocks.onCloseRequested.mock.calls[0][0];
       const event = { preventDefault: vi.fn() };
@@ -212,6 +228,24 @@ describe('updater', () => {
       expect(marker.failed).toBe(true);
       expect(marker.version).toBe('0.5.0');
       expect(mocks.windowClose).toHaveBeenCalled();
+    });
+
+    it('does not install an available update before approval', async () => {
+      const update = makeUpdate('0.5.0');
+      mocks.check.mockResolvedValue(update);
+
+      startUpdateCheck();
+      await vi.advanceTimersByTimeAsync(5_000);
+      await vi.advanceTimersByTimeAsync(0);
+
+      const closeHandler = mocks.onCloseRequested.mock.calls[0][0];
+      const event = { preventDefault: vi.fn() };
+
+      await closeHandler(event);
+
+      expect(event.preventDefault).not.toHaveBeenCalled();
+      expect(update.download).not.toHaveBeenCalled();
+      expect(update.install).not.toHaveBeenCalled();
     });
 
     it('does not prevent close when no update is pending', async () => {

--- a/standalone/src/updater.test.ts
+++ b/standalone/src/updater.test.ts
@@ -265,9 +265,13 @@ describe('updater', () => {
   });
 
   describe('actions', () => {
-    it('openChangelog calls shell open', () => {
+    it('openChangelog opens the release notes after the current app version', async () => {
+      startUpdateCheck();
+      await vi.advanceTimersByTimeAsync(0);
+
       openChangelog();
-      expect(mocks.shellOpen).toHaveBeenCalledWith('https://mouseterm.com/changelog');
+
+      expect(mocks.shellOpen).toHaveBeenCalledWith('https://mouseterm.com/changelog/after/0.4.0');
     });
   });
 

--- a/standalone/src/updater.test.ts
+++ b/standalone/src/updater.test.ts
@@ -265,11 +265,9 @@ describe('updater', () => {
   });
 
   describe('actions', () => {
-    it('openChangelog opens the release notes after the current app version', async () => {
-      startUpdateCheck();
-      await vi.advanceTimersByTimeAsync(0);
-
+    it('openChangelog reads the current app version and opens release notes after it', async () => {
       openChangelog();
+      await vi.advanceTimersByTimeAsync(0);
 
       expect(mocks.shellOpen).toHaveBeenCalledWith('https://mouseterm.com/changelog/after/0.4.0');
     });

--- a/standalone/src/updater.ts
+++ b/standalone/src/updater.ts
@@ -60,7 +60,9 @@ export function approveUpdate(): void {
 }
 
 export function openChangelog(): void {
-  openUrl('https://mouseterm.com/changelog', 'changelog');
+  const version = currentVersion.trim();
+  const path = version ? `/changelog/after/${encodeURIComponent(version)}` : '/changelog';
+  openUrl(`https://mouseterm.com${path}`, 'changelog');
 }
 
 export async function buildDebugReport(error: string, toVersion: string): Promise<string> {

--- a/standalone/src/updater.ts
+++ b/standalone/src/updater.ts
@@ -18,7 +18,9 @@ function openUrl(url: string, context: string): void {
 const STORAGE_KEY = 'mouseterm:update-result';
 
 let state: UpdateBannerState = { status: 'idle' };
+let availableUpdate: Update | null = null;
 let pendingUpdate: Update | null = null;
+let downloadPromise: Promise<void> | null = null;
 let currentVersion = '';
 
 const listeners = new Set<() => void>();
@@ -51,6 +53,10 @@ export function useUpdateState(): UpdateBannerState {
 
 export function dismissBanner(): void {
   setState({ status: 'dismissed' });
+}
+
+export function approveUpdate(): void {
+  void downloadApprovedUpdate();
 }
 
 export function openChangelog(): void {
@@ -126,9 +132,8 @@ async function runUpdateCheck(): Promise<void> {
     // Corrupt marker — ignore
   }
 
-  // Skip the auto-update probe on a failure-marker launch: re-downloading the
-  // same version that just failed will fail again on quit, and the state
-  // transition to `downloaded` would unmount any open debug dialog.
+  // Skip the auto-update probe on a failure-marker launch: prompting for the
+  // same version that just failed would unmount any open debug dialog.
   if (hadFailureMarker) {
     registerCloseHandler();
     return;
@@ -144,14 +149,43 @@ async function runUpdateCheck(): Promise<void> {
       return;
     }
 
-    await update.download();
-    pendingUpdate = update;
-    setState({ status: 'downloaded', version: update.version });
+    availableUpdate = update;
+    setState({ status: 'available', version: update.version });
   } catch (e) {
-    console.error('[updater] Check/download failed:', e);
+    console.error('[updater] Check failed:', e);
   }
 
   registerCloseHandler();
+}
+
+async function downloadApprovedUpdate(): Promise<void> {
+  if (downloadPromise) {
+    await downloadPromise;
+    return;
+  }
+
+  const update = availableUpdate;
+  if (!update) return;
+
+  setState({ status: 'downloading', version: update.version });
+
+  downloadPromise = (async () => {
+    try {
+      await update.download();
+      availableUpdate = null;
+      pendingUpdate = update;
+      setState({ status: 'downloaded', version: update.version });
+    } catch (e) {
+      console.error('[updater] Download failed:', e);
+      if (availableUpdate === update) {
+        setState({ status: 'available', version: update.version });
+      }
+    } finally {
+      downloadPromise = null;
+    }
+  })();
+
+  await downloadPromise;
 }
 
 // --- Test support ---
@@ -159,7 +193,9 @@ async function runUpdateCheck(): Promise<void> {
 /** @internal Reset all module state for testing. */
 export function _resetForTesting(): void {
   state = { status: 'idle' };
+  availableUpdate = null;
   pendingUpdate = null;
+  downloadPromise = null;
   currentVersion = '';
   closeHandlerRegistered = false;
   listeners.clear();

--- a/standalone/src/updater.ts
+++ b/standalone/src/updater.ts
@@ -139,7 +139,6 @@ async function runUpdateCheck(): Promise<void> {
     return;
   }
 
-  // Wait 5 seconds, then check for updates
   await new Promise((resolve) => setTimeout(resolve, 5_000));
 
   try {
@@ -174,10 +173,14 @@ async function downloadApprovedUpdate(): Promise<void> {
       await update.download();
       availableUpdate = null;
       pendingUpdate = update;
-      setState({ status: 'downloaded', version: update.version });
+      // Honor a dismissal that arrived during the download — install still
+      // happens on quit because pendingUpdate is set.
+      if (state.status === 'downloading') {
+        setState({ status: 'downloaded', version: update.version });
+      }
     } catch (e) {
       console.error('[updater] Download failed:', e);
-      if (availableUpdate === update) {
+      if (state.status === 'downloading' && availableUpdate === update) {
         setState({ status: 'available', version: update.version });
       }
     } finally {
@@ -210,7 +213,8 @@ function registerCloseHandler(): void {
   closeHandlerRegistered = true;
 
   getCurrentWindow().onCloseRequested(async (event) => {
-    if (!pendingUpdate) return;
+    const update = pendingUpdate;
+    if (!update) return;
 
     if (shouldSkipInstallInDev()) {
       console.warn('[updater] Skipping update install in dev mode. Use a packaged app to test install.');
@@ -224,14 +228,14 @@ function registerCloseHandler(): void {
       // Write success marker BEFORE install — on Windows, NSIS force-kills the process
       localStorage.setItem(STORAGE_KEY, JSON.stringify({
         from: currentVersion,
-        to: pendingUpdate.version,
+        to: update.version,
       }));
-      await pendingUpdate.install();
+      await update.install();
     } catch (e) {
       // Overwrite with failure marker
       localStorage.setItem(STORAGE_KEY, JSON.stringify({
         failed: true,
-        version: pendingUpdate!.version,
+        version: update.version,
         error: String(e),
       }));
       console.error('[updater] Install failed:', e);

--- a/standalone/src/updater.ts
+++ b/standalone/src/updater.ts
@@ -60,9 +60,12 @@ export function approveUpdate(): void {
 }
 
 export function openChangelog(): void {
-  const version = currentVersion.trim();
-  const path = version ? `/changelog/after/${encodeURIComponent(version)}` : '/changelog';
-  openUrl(`https://mouseterm.com${path}`, 'changelog');
+  void openCurrentVersionChangelog();
+}
+
+async function openCurrentVersionChangelog(): Promise<void> {
+  const version = (await getVersion()).trim();
+  openUrl(`https://mouseterm.com/changelog/after/${encodeURIComponent(version)}`, 'changelog');
 }
 
 export async function buildDebugReport(error: string, toVersion: string): Promise<string> {
@@ -100,11 +103,7 @@ export function startUpdateCheck(): void {
 }
 
 async function runUpdateCheck(): Promise<void> {
-  try {
-    currentVersion = await getVersion();
-  } catch {
-    currentVersion = '';
-  }
+  currentVersion = await getVersion();
 
   let hadFailureMarker = false;
 


### PR DESCRIPTION
## Summary
- Changed the standalone updater so update checks only surface an approval prompt; download and install now happen only after the user clicks "Install on quit".
- Made the changelog action open `https://mouseterm.com/changelog/after/<current-version>` by reading the app version from Tauri at click time.
- Updated the auto-update spec, updater tests, and Storybook stories to match the approval-first flow.

## Testing
- `pnpm --filter mouseterm-standalone test`
- `pnpm --filter mouseterm-standalone build`
- `pnpm --filter mouseterm-lib build`