### PR TITLE
Refine the mobile terminal layout and gesture modes

### DIFF
--- a/docs/specs/mobile-ui.md
+++ b/docs/specs/mobile-ui.md
@@ -89,11 +89,11 @@ Touch modes:
 | --- | --- | --- | --- | --- |
 | Gestures | `Gestures` | `HandPointingIcon` | Always available | Touch drags generate arrow keys. Drag left sends left, drag right sends right, drag up sends up, and drag down sends down. |
 | Text selection | `Select` | `CursorTextIcon` | Always available | Touches are reserved for terminal text selection and copy/paste. If the TUI is capturing mouse events, MouseTerm activates mouse override for the active pane. |
-| Cursor | `Cursor` | `CursorClickIcon` | Only when the active TUI is capturing mouse events | Touches are passed through as terminal mouse/cursor input. |
+| Mouse | `Mouse` | `CursorClickIcon` | Only when the active TUI is capturing mouse events | Touches are passed through as terminal mouse input. |
 
 Default touch mode is **Gestures**.
 
-If Cursor mode is active and the active pane stops capturing mouse events, the
+If Mouse mode is active and the active pane stops capturing mouse events, the
 selector must fall back to Gestures.
 
 ## 5. Keyboard Mode Selector
@@ -106,17 +106,18 @@ Recent | Type | Draft | Keys
 ```
 
 The selector must be self-labeling. It should use a compact left-side `Input`
-label plus segmented text buttons. The label describes the reserve area's
+label plus segmented buttons that include both an icon and a short mode label.
+The label describes the reserve area's
 purpose without adding a longer instruction line.
 
 Keyboard modes:
 
-| Mode | Reserve area content |
-| --- | --- |
-| Recent | The entire reserve area displays `Recent - WIP`. |
-| Type | The reserve area focuses the hidden terminal input. Every typed key is echoed into the terminal as it happens. |
-| Draft | The entire reserve area displays `Draft - WIP`. |
-| Keys | The entire reserve area displays terminal key buttons. |
+| Mode | Button label | Icon | Reserve area content |
+| --- | --- | --- | --- |
+| Recent | `Recent` | `ClockCounterClockwiseIcon` | The entire reserve area displays `Recent - WIP`. |
+| Type | `Type` | `TextTIcon` | The reserve area focuses the hidden terminal input. Every typed key is echoed into the terminal as it happens. |
+| Draft | `Draft` | `ArticleNyTimesIcon` | The entire reserve area displays `Draft - WIP`. |
+| Keys | `Keys` | `KeyboardIcon` | The entire reserve area displays terminal key buttons. |
 
 Default keyboard mode is **Type**.
 
@@ -231,7 +232,7 @@ Required interactions:
 * Tap key buttons in Keys mode.
 * Drag in Gestures mode to send arrow keys.
 * Use Text selection mode for terminal selection and copy/paste.
-* Use Cursor mode for terminal mouse/cursor input when a TUI requests mouse reporting.
+* Use Mouse mode for terminal mouse input when a TUI requests mouse reporting.
 
 Pane-content touches must never open the native keyboard. The pane content area
 may focus the terminal internally for key routing or mouse handling, but the
@@ -270,7 +271,7 @@ Build exactly this:
 * Touch mode selector:
 
 ```text
-Touch  Gestures | Select | Cursor
+Touch  Gestures | Select | Mouse
 ```
 
 * Keyboard mode selector:
@@ -300,7 +301,7 @@ The prototype should answer these questions:
 2. Is the touch mode selector understandable and reachable?
 3. Are gesture arrows usable enough for command history and cursor movement?
 4. Is text selection discoverable and reliable on mobile?
-5. Is Cursor mode useful when a TUI captures mouse events?
+5. Is Mouse mode useful when a TUI captures mouse events?
 6. Does native keyboard Type mode feel acceptable for terminal text entry?
 7. Does the stable keyboard reserve feel better than resizing the whole UI?
 8. Is the UI too cramped in portrait orientation?

--- a/docs/specs/mobile-ui.md
+++ b/docs/specs/mobile-ui.md
@@ -127,9 +127,9 @@ Input modes:
 | Mode | Button label | Icon | Reserve area content |
 | --- | --- | --- | --- |
 | Sessions | `Sessions` | `TerminalWindowIcon` | The reserve area displays mobile session rows with active, alert, and TODO state. Selecting a session makes it the single visible terminal. |
-| Recent | `Recent` | `ClockCounterClockwiseIcon` | The entire reserve area displays `Recent - WIP`. |
-| Type | `Type` | `TextTIcon` | The reserve area focuses the hidden terminal input. Every typed key is echoed into the terminal as it happens. |
-| Draft | `Draft` | `ArticleNyTimesIcon` | The entire reserve area displays `Draft - WIP`. |
+| Recent | `Recent` | `ClockCounterClockwiseIcon` | The entire reserve area displays `WIP - commands you have recently executed will be available here`. |
+| Type | `Type` | `TextTIcon` | The reserve area displays `Onscreen keyboard goes here` and focuses the hidden terminal input. Every typed key is echoed into the terminal as it happens. |
+| Draft | `Draft` | `ArticleNyTimesIcon` | The entire reserve area displays `WIP - this will be a place to draft prompts before pasting into the terminal`. |
 
 Default input mode is **Type**.
 
@@ -204,7 +204,8 @@ The keyboard reserve area has a stable height. It should not be recomputed from
 `visualViewport` while the native keyboard animates.
 
 When the OS keyboard is hidden, the reserve area shows the selected app keyboard
-UI (session list, `Recent - WIP`, Type focus target, or `Draft - WIP`).
+UI: session list, `WIP - commands you have recently executed will be available here`,
+`Onscreen keyboard goes here`, or `WIP - this will be a place to draft prompts before pasting into the terminal`.
 
 When the OS keyboard is visible, the OS keyboard may cover or occupy that same
 physical area. This is preferred over resizing the whole app around the keyboard.
@@ -270,8 +271,8 @@ Sessions | Recent | Type | Draft
 
 * Stable keyboard reserve area.
 * Sessions reserve content: active session rows with alert and TODO state.
-* Recent reserve content: `Recent - WIP`.
-* Draft reserve content: `Draft - WIP`.
+* Recent reserve content: `WIP - commands you have recently executed will be available here`.
+* Draft reserve content: `WIP - this will be a place to draft prompts before pasting into the terminal`.
 * Type mode native mobile keyboard input.
 * Simple local playground terminal behavior.
 

--- a/docs/specs/mobile-ui.md
+++ b/docs/specs/mobile-ui.md
@@ -113,10 +113,10 @@ selector must fall back to Gestures.
 ## 5. Input Mode Selector
 
 The input mode selector controls what appears in the reserve area. It is always
-visible and has five items:
+visible and has four items:
 
 ```text
-Sessions | Recent | Type | Draft | Keys
+Sessions | Recent | Type | Draft
 ```
 
 The selector must be self-labeling through segmented buttons that include both
@@ -130,7 +130,6 @@ Input modes:
 | Recent | `Recent` | `ClockCounterClockwiseIcon` | The entire reserve area displays `Recent - WIP`. |
 | Type | `Type` | `TextTIcon` | The reserve area focuses the hidden terminal input. Every typed key is echoed into the terminal as it happens. |
 | Draft | `Draft` | `ArticleNyTimesIcon` | The entire reserve area displays `Draft - WIP`. |
-| Keys | `Keys` | `KeyboardIcon` | The entire reserve area displays terminal key buttons. |
 
 Default input mode is **Type**.
 
@@ -143,31 +142,7 @@ the tap/click handler. Do not defer this focus to `requestAnimationFrame` or a
 timer, because mobile browsers may then treat it as no longer user-initiated and
 refuse to open the native keyboard.
 
-## 6. Keys Mode
-
-Keys mode displays exactly these buttons:
-
-```text
-Esc   Tab   Space   Enter
-←     ↓     ↑       →
-```
-
-Mappings:
-
-| Button | Sequence |
-| --- | --- |
-| Esc | `\x1B` |
-| Tab | `\x09` |
-| Space | ` ` |
-| Enter | `\r` |
-| ← | `\x1B[D` |
-| ↓ | `\x1B[B` |
-| ↑ | `\x1B[A` |
-| → | `\x1B[C` |
-
-Tapping a key sends exactly one action. Long-press repeat is not required for v0.
-
-## 7. Type Mode Input
+## 6. Type Mode Input
 
 Use a hidden or visually minimal input configured for terminal-style typing:
 
@@ -192,7 +167,7 @@ Required behavior:
 * Input supports mobile keyboard behavior and IME composition.
 * The app does not depend only on `keydown` for text input.
 
-## 8. Terminal Playground Behavior
+## 7. Terminal Playground Behavior
 
 A fake shell is acceptable for v0.
 
@@ -202,7 +177,7 @@ Minimum useful behavior:
 * Maintain a command line buffer.
 * Enter submits the current command.
 * Backspace edits the current command.
-* Arrow keys produce visible behavior.
+* Gesture-generated arrow keys produce visible behavior.
 * Escape and Tab produce visible behavior.
 * When a fake full-screen app such as `ascii-splash`, `splash`, `changelog`, or
   `tut` is running, `Ctrl+C` sends `\x03` to that app; if the app exits, the
@@ -223,19 +198,18 @@ tut
 
 The shell only needs enough behavior to test the mobile controls.
 
-## 9. Keyboard Reserve
+## 8. Keyboard Reserve
 
 The keyboard reserve area has a stable height. It should not be recomputed from
 `visualViewport` while the native keyboard animates.
 
 When the OS keyboard is hidden, the reserve area shows the selected app keyboard
-UI (session list, `Recent - WIP`, Type focus target, `Draft - WIP`, or Keys
-buttons).
+UI (session list, `Recent - WIP`, Type focus target, or `Draft - WIP`).
 
 When the OS keyboard is visible, the OS keyboard may cover or occupy that same
 physical area. This is preferred over resizing the whole app around the keyboard.
 
-## 10. Touch Interactions
+## 9. Touch Interactions
 
 Required interactions:
 
@@ -244,7 +218,6 @@ Required interactions:
 * Switch active sessions through Sessions mode.
 * Tap Type reserve area to focus typing.
 * Type through the native keyboard.
-* Tap key buttons in Keys mode.
 * Drag in Gestures mode to send arrow keys.
 * Use Text selection mode for terminal selection and copy/paste.
 * Use Mouse mode for terminal mouse input when a TUI requests mouse reporting.
@@ -266,7 +239,7 @@ Not required for v0:
 * A full command history UI.
 * A real draft editor.
 
-## 11. Copy And Paste
+## 10. Copy And Paste
 
 Keep copy and paste minimal.
 
@@ -277,7 +250,7 @@ Prototype behavior:
 * No custom mobile clipboard manager is required.
 * No multi-line paste review is required.
 
-## 12. Recommended v0 Scope
+## 11. Recommended v0 Scope
 
 Build exactly this:
 
@@ -292,7 +265,7 @@ Gestures | Select | Mouse
 * Input mode selector:
 
 ```text
-Sessions | Recent | Type | Draft | Keys
+Sessions | Recent | Type | Draft
 ```
 
 * Stable keyboard reserve area.
@@ -300,16 +273,9 @@ Sessions | Recent | Type | Draft | Keys
 * Recent reserve content: `Recent - WIP`.
 * Draft reserve content: `Draft - WIP`.
 * Type mode native mobile keyboard input.
-* Keys buttons:
-
-```text
-Esc   Tab   Space   Enter
-←     ↓     ↑       →
-```
-
 * Simple local playground terminal behavior.
 
-## 13. Prototype Success Criteria
+## 12. Prototype Success Criteria
 
 The prototype should answer these questions:
 
@@ -322,7 +288,7 @@ The prototype should answer these questions:
 7. Does the stable keyboard reserve feel better than resizing the whole UI?
 8. Is the UI too cramped in portrait orientation?
 
-## 14. Future Work
+## 13. Future Work
 
 Potential later additions:
 
@@ -341,7 +307,7 @@ Potential later additions:
 * Multi-session support.
 * Production security model.
 
-## 15. Product Principle
+## 14. Product Principle
 
 The v0 prototype should stay focused:
 

--- a/docs/specs/mobile-ui.md
+++ b/docs/specs/mobile-ui.md
@@ -7,7 +7,7 @@ This document specifies the `/tether` mobile terminal prototype.
 The prototype tests one core idea:
 
 ```text
-Stable terminal viewport + explicit touch mode + explicit keyboard mode.
+Stable terminal viewport + mobile session viewport + explicit touch mode + explicit input mode.
 ```
 
 The app should feel like a lightweight mobile terminal playground. It does not
@@ -27,7 +27,8 @@ Primary goals:
 
 * Keep the terminal viewport stable when the native phone keyboard opens or closes.
 * Let the user explicitly choose what terminal touches mean.
-* Let the user explicitly choose what appears in the stable keyboard reserve area.
+* Let the user explicitly choose what appears in the stable reserve area.
+* Show one terminal session at a time on mobile, with session switching available from the reserve controls.
 * Test normal mobile text entry using the native phone keyboard.
 * Provide enough terminal behavior to evaluate typing, Enter, Backspace, arrows, Escape, Tab, and app interruption.
 * Keep the implementation small and easy to iterate on.
@@ -41,6 +42,7 @@ Non-goals:
 * Session persistence.
 * Command history storage.
 * A real draft/scratchpad workflow.
+* Mobile split-pane layout.
 * Advanced gestures.
 * Production security hardening.
 * Full accessibility implementation.
@@ -51,25 +53,35 @@ The mobile UI is split into fixed and flexible regions:
 
 ```text
 ┌─────────────────────────┐
-│ Pane title               │ fixed/small
+│ Mobile session header     │ fixed/small
 ├─────────────────────────┤
 │ Pane content             │ flexible terminal area
 ├─────────────────────────┤
-│ Touch mode selector      │ labeled, always visible
+│ Touch mode selector      │ always visible
 ├─────────────────────────┤
-│ Keyboard mode selector   │ labeled, always visible
+│ Reserve mode selector    │ always visible
 ├─────────────────────────┤
-│ Keyboard reserve area    │ stable height
+│ Reserve area             │ stable height
 │                         │
 │ Shows app keyboard UI    │ when OS keyboard hidden
 │ Occupied by OS keyboard  │ when OS keyboard visible
 └─────────────────────────┘
 ```
 
-The pane title and pane content come from the embedded `Wall` terminal pane. The
-mobile wrapper owns the two selectors and the fixed-height keyboard reserve.
-The selector block should use one divider between the Touch and Input rows, with
-no divider above Touch and no divider below Input.
+The mobile session header and pane content come from `MobileWall`, a mobile
+composition that displays one active terminal session at a time. Desktop `Wall`
+remains the tiling workspace; mobile does not expose split-pane layout. The
+mobile wrapper owns the two selectors and the fixed-height reserve. The selector
+block should use one divider between the Touch and Input rows, with no divider
+above Touch and no divider below Input. The mobile session header should not use
+the desktop terminal title corner radius; it is a flush mobile bar. The alert
+bell sits immediately after the title before secondary title detail. The mobile
+header keeps a minimize button, and in the `/tether` prototype that action opens
+the Sessions reserve instead of creating a desktop Door. The Touch row and its
+selector tray should sit on `terminal-bg` so they read as part of the terminal
+surface above. The Input row and reserve area should sit on
+`header-inactive-bg` with `header-inactive-fg`, so the lower input controls are
+distinct from the terminal while still following the selected theme.
 
 The root height must not be recalculated from `window.visualViewport` on every
 keyboard resize. The reserve area is intentionally stable so the terminal region
@@ -78,12 +90,12 @@ does not bounce while the OS keyboard animates.
 ## 4. Touch Mode Selector
 
 The touch selector controls what happens when the user touches the pane content
-area. It is always visible between the terminal content and the keyboard mode
+area. It is always visible between the terminal content and the input mode
 selector.
 
-The selector must be self-labeling. It should use a compact left-side `Touch`
-label plus segmented buttons that include both an icon and a short mode label.
-Icon-only touch controls are too hard to discover in this prototype.
+The selector must be self-labeling through segmented buttons that include both
+an icon and a short mode label. Icon-only touch controls are too hard to
+discover in this prototype.
 
 Touch modes:
 
@@ -98,30 +110,29 @@ Default touch mode is **Gestures**.
 If Mouse mode is active and the active pane stops capturing mouse events, the
 selector must fall back to Gestures.
 
-## 5. Keyboard Mode Selector
+## 5. Input Mode Selector
 
-The keyboard mode selector controls what appears in the keyboard reserve area.
-It is always visible and has four items:
+The input mode selector controls what appears in the reserve area. It is always
+visible and has five items:
 
 ```text
-Recent | Type | Draft | Keys
+Sessions | Recent | Type | Draft | Keys
 ```
 
-The selector must be self-labeling. It should use a compact left-side `Input`
-label plus segmented buttons that include both an icon and a short mode label.
-The label describes the reserve area's
-purpose without adding a longer instruction line.
+The selector must be self-labeling through segmented buttons that include both
+an icon and a short mode label.
 
-Keyboard modes:
+Input modes:
 
 | Mode | Button label | Icon | Reserve area content |
 | --- | --- | --- | --- |
+| Sessions | `Sessions` | `TerminalWindowIcon` | The reserve area displays mobile session rows with active, alert, and TODO state. Selecting a session makes it the single visible terminal. |
 | Recent | `Recent` | `ClockCounterClockwiseIcon` | The entire reserve area displays `Recent - WIP`. |
 | Type | `Type` | `TextTIcon` | The reserve area focuses the hidden terminal input. Every typed key is echoed into the terminal as it happens. |
 | Draft | `Draft` | `ArticleNyTimesIcon` | The entire reserve area displays `Draft - WIP`. |
 | Keys | `Keys` | `KeyboardIcon` | The entire reserve area displays terminal key buttons. |
 
-Default keyboard mode is **Type**.
+Default input mode is **Type**.
 
 Switching to Type should focus the hidden input and open the native keyboard
 where browser policy allows. Switching away from Type should blur the hidden
@@ -218,7 +229,8 @@ The keyboard reserve area has a stable height. It should not be recomputed from
 `visualViewport` while the native keyboard animates.
 
 When the OS keyboard is hidden, the reserve area shows the selected app keyboard
-UI (`Recent - WIP`, Type focus target, `Draft - WIP`, or Keys buttons).
+UI (session list, `Recent - WIP`, Type focus target, `Draft - WIP`, or Keys
+buttons).
 
 When the OS keyboard is visible, the OS keyboard may cover or occupy that same
 physical area. This is preferred over resizing the whole app around the keyboard.
@@ -227,8 +239,9 @@ physical area. This is preferred over resizing the whole app around the keyboard
 
 Required interactions:
 
-* Tap keyboard mode selector items.
+* Tap input mode selector items.
 * Tap touch mode selector items.
+* Switch active sessions through Sessions mode.
 * Tap Type reserve area to focus typing.
 * Type through the native keyboard.
 * Tap key buttons in Keys mode.
@@ -273,16 +286,17 @@ Build exactly this:
 * Touch mode selector:
 
 ```text
-Touch  Gestures | Select | Mouse
+Gestures | Select | Mouse
 ```
 
-* Keyboard mode selector:
+* Input mode selector:
 
 ```text
-Input  Recent | Type | Draft | Keys
+Sessions | Recent | Type | Draft | Keys
 ```
 
 * Stable keyboard reserve area.
+* Sessions reserve content: active session rows with alert and TODO state.
 * Recent reserve content: `Recent - WIP`.
 * Draft reserve content: `Draft - WIP`.
 * Type mode native mobile keyboard input.
@@ -333,6 +347,6 @@ The v0 prototype should stay focused:
 
 ```text
 Touch modes make pane touches explicit.
-Keyboard modes make the reserve area explicit.
+Input modes make the reserve area explicit.
 Everything else waits.
 ```

--- a/docs/specs/mobile-ui.md
+++ b/docs/specs/mobile-ui.md
@@ -68,6 +68,8 @@ The mobile UI is split into fixed and flexible regions:
 
 The pane title and pane content come from the embedded `Wall` terminal pane. The
 mobile wrapper owns the two selectors and the fixed-height keyboard reserve.
+The selector block should use one divider between the Touch and Input rows, with
+no divider above Touch and no divider below Input.
 
 The root height must not be recalculated from `window.visualViewport` on every
 keyboard resize. The reserve area is intentionally stable so the terminal region

--- a/lib/src/components/MobileTerminalUi.tsx
+++ b/lib/src/components/MobileTerminalUi.tsx
@@ -10,15 +10,20 @@ import {
   type ReactNode,
 } from 'react';
 import {
+  ArticleNyTimesIcon,
+  ClockCounterClockwiseIcon,
   CursorClickIcon,
   CursorTextIcon,
   HandPointingIcon,
+  KeyboardIcon,
+  TextTIcon,
 } from '@phosphor-icons/react';
 import { clsx } from 'clsx';
 
 export type MobileTerminalKeyboardMode = 'recent' | 'type' | 'draft' | 'keys';
 export type MobileTerminalSection = MobileTerminalKeyboardMode;
 export type MobileTerminalTouchMode = 'gestures' | 'selection' | 'cursor';
+type PhosphorIcon = ComponentType<{ size?: number; weight?: 'regular' | 'bold' | 'duotone' | 'fill' }>;
 
 export const MOBILE_TERMINAL_KEY_SEQUENCES = {
   ctrlC: '\x03',
@@ -50,11 +55,11 @@ const TERMINAL_KEYS: TerminalKey[] = [
   { id: 'right', label: '\u2192', title: 'Right arrow' },
 ];
 
-const KEYBOARD_MODES: { id: MobileTerminalKeyboardMode; label: string }[] = [
-  { id: 'recent', label: 'Recent' },
-  { id: 'type', label: 'Type' },
-  { id: 'draft', label: 'Draft' },
-  { id: 'keys', label: 'Keys' },
+const KEYBOARD_MODES: Array<{ id: MobileTerminalKeyboardMode; label: string; Icon: PhosphorIcon }> = [
+  { id: 'recent', label: 'Recent', Icon: ClockCounterClockwiseIcon },
+  { id: 'type', label: 'Type', Icon: TextTIcon },
+  { id: 'draft', label: 'Draft', Icon: ArticleNyTimesIcon },
+  { id: 'keys', label: 'Keys', Icon: KeyboardIcon },
 ];
 
 const TOUCH_MODES: Array<{
@@ -62,11 +67,11 @@ const TOUCH_MODES: Array<{
   label: string;
   shortLabel: string;
   title: string;
-  Icon: ComponentType<{ size?: number; weight?: 'regular' | 'bold' | 'duotone' | 'fill' }>;
+  Icon: PhosphorIcon;
 }> = [
   { id: 'gestures', label: 'Gestures', shortLabel: 'Gestures', title: 'Gestures: drags send arrow keys', Icon: HandPointingIcon },
   { id: 'selection', label: 'Text selection', shortLabel: 'Select', title: 'Text selection: touches select terminal text', Icon: CursorTextIcon },
-  { id: 'cursor', label: 'Cursor', shortLabel: 'Cursor', title: 'Cursor: touches send terminal mouse events', Icon: CursorClickIcon },
+  { id: 'cursor', label: 'Mouse', shortLabel: 'Mouse', title: 'Mouse: touches send terminal mouse events', Icon: CursorClickIcon },
 ];
 
 export interface MobileTerminalUiProps {
@@ -148,12 +153,14 @@ function KeyButton({
 function KeyboardModeButton({
   id,
   label,
+  Icon,
   selected,
   disabled,
   onSelect,
 }: {
   id: MobileTerminalKeyboardMode;
   label: string;
+  Icon: PhosphorIcon;
   selected: boolean;
   disabled: boolean;
   onSelect: (mode: MobileTerminalKeyboardMode) => void;
@@ -167,14 +174,17 @@ function KeyboardModeButton({
       aria-current={selected ? 'page' : undefined}
       onClick={() => onSelect(id)}
       className={clsx(
-        'min-w-0 rounded px-1.5 py-1 font-mono text-xs leading-none transition-colors focus-visible:outline focus-visible:outline-1 focus-visible:outline-offset-1 focus-visible:outline-focus-ring',
+        'flex min-w-0 items-center justify-center gap-1 rounded px-1.5 py-1 font-mono text-xs leading-none transition-colors focus-visible:outline focus-visible:outline-1 focus-visible:outline-offset-1 focus-visible:outline-focus-ring',
         'disabled:pointer-events-none disabled:opacity-60',
         selected
           ? 'bg-header-active-bg text-header-active-fg shadow-[inset_0_0_0_1px_var(--color-focus-ring)]'
           : 'text-muted hover:bg-header-inactive-bg hover:text-foreground',
       )}
     >
-      <span className="truncate">{label}</span>
+      <span aria-hidden="true" className="shrink-0">
+        <Icon size={15} weight={selected ? 'bold' : 'regular'} />
+      </span>
+      <span className="min-w-0 truncate">{label}</span>
     </button>
   );
 }
@@ -258,6 +268,7 @@ function KeyboardModeSelector({
             key={item.id}
             id={item.id}
             label={item.label}
+            Icon={item.Icon}
             selected={item.id === mode}
             disabled={disabled}
             onSelect={onSelect}

--- a/lib/src/components/MobileTerminalUi.tsx
+++ b/lib/src/components/MobileTerminalUi.tsx
@@ -11,19 +11,31 @@ import {
 } from 'react';
 import {
   ArticleNyTimesIcon,
+  BellIcon,
   ClockCounterClockwiseIcon,
   CursorClickIcon,
   CursorTextIcon,
   HandPointingIcon,
   KeyboardIcon,
+  TerminalWindowIcon,
   TextTIcon,
 } from '@phosphor-icons/react';
 import { clsx } from 'clsx';
+import { bellIconClass } from './bell-icon-class';
 
-export type MobileTerminalKeyboardMode = 'recent' | 'type' | 'draft' | 'keys';
+export type MobileTerminalKeyboardMode = 'sessions' | 'recent' | 'type' | 'draft' | 'keys';
 export type MobileTerminalSection = MobileTerminalKeyboardMode;
 export type MobileTerminalTouchMode = 'gestures' | 'selection' | 'cursor';
 type PhosphorIcon = ComponentType<{ size?: number; weight?: 'regular' | 'bold' | 'duotone' | 'fill' }>;
+
+export interface MobileTerminalSessionItem {
+  id: string;
+  title: string;
+  secondary?: string | null;
+  active?: boolean;
+  status?: 'ALERT_DISABLED' | 'NOTHING_TO_SHOW' | 'MIGHT_BE_BUSY' | 'BUSY' | 'MIGHT_NEED_ATTENTION' | 'ALERT_RINGING' | 'OSC_NOTIF_BUSY';
+  todo?: boolean;
+}
 
 export const MOBILE_TERMINAL_KEY_SEQUENCES = {
   ctrlC: '\x03',
@@ -56,6 +68,7 @@ const TERMINAL_KEYS: TerminalKey[] = [
 ];
 
 const KEYBOARD_MODES: Array<{ id: MobileTerminalKeyboardMode; label: string; Icon: PhosphorIcon }> = [
+  { id: 'sessions', label: 'Sessions', Icon: TerminalWindowIcon },
   { id: 'recent', label: 'Recent', Icon: ClockCounterClockwiseIcon },
   { id: 'type', label: 'Type', Icon: TextTIcon },
   { id: 'draft', label: 'Draft', Icon: ArticleNyTimesIcon },
@@ -88,6 +101,8 @@ export interface MobileTerminalUiProps {
   cursorTouchAvailable?: boolean;
   onSendInput?: (data: string) => void;
   onFocusInput?: () => void;
+  sessions?: MobileTerminalSessionItem[];
+  onSessionSelect?: (id: string) => void;
   interactive?: boolean;
   fillViewport?: boolean;
   className?: string;
@@ -170,7 +185,7 @@ function KeyboardModeButton({
       key={id}
       type="button"
       disabled={disabled}
-      aria-label={`${label} keyboard mode`}
+      aria-label={`${label} input mode`}
       aria-current={selected ? 'page' : undefined}
       onClick={() => onSelect(id)}
       className={clsx(
@@ -189,14 +204,6 @@ function KeyboardModeButton({
   );
 }
 
-function SelectorLabel({ children }: { children: ReactNode }) {
-  return (
-    <div className="w-12 shrink-0 pl-2 pr-1 font-mono text-xs leading-none text-muted">
-      {children}
-    </div>
-  );
-}
-
 function TouchModeSelector({
   mode,
   cursorAvailable,
@@ -211,10 +218,9 @@ function TouchModeSelector({
   return (
     <section
       aria-label="Touch mode"
-      className="flex h-9 shrink-0 items-center bg-app-bg"
+      className="flex h-9 shrink-0 items-center bg-terminal-bg px-2"
     >
-      <SelectorLabel>Touch</SelectorLabel>
-      <div className="mr-2 grid min-w-0 flex-1 grid-cols-3 gap-1 rounded bg-surface-raised p-1 shadow-[inset_0_0_0_1px_var(--color-border)]">
+      <div className="grid min-w-0 flex-1 grid-cols-3 gap-1 rounded bg-terminal-bg p-1 shadow-[inset_0_0_0_1px_var(--color-border)]">
         {TOUCH_MODES.map((item) => {
           const selected = item.id === mode;
           const itemDisabled = disabled || (item.id === 'cursor' && !cursorAvailable);
@@ -258,11 +264,10 @@ function KeyboardModeSelector({
 }) {
   return (
     <section
-      aria-label="Keyboard mode"
-      className="flex h-9 shrink-0 items-center border-t border-border bg-app-bg"
+      aria-label="Input mode"
+      className="flex h-9 shrink-0 items-center border-t border-border bg-header-inactive-bg px-2 text-header-inactive-fg"
     >
-      <SelectorLabel>Input</SelectorLabel>
-      <nav className="mr-2 grid min-w-0 flex-1 grid-cols-4 gap-1 rounded bg-surface-raised p-1 shadow-[inset_0_0_0_1px_var(--color-border)]">
+      <nav className="grid min-w-0 flex-1 grid-cols-[1.35fr_repeat(4,minmax(0,1fr))] gap-1 rounded bg-header-inactive-bg p-1 shadow-[inset_0_0_0_1px_var(--color-border)]">
         {KEYBOARD_MODES.map((item) => (
           <KeyboardModeButton
             key={item.id}
@@ -287,6 +292,76 @@ function WorkInProgressPane({ label }: { label: 'Recent' | 'Draft' }) {
   );
 }
 
+function SessionsPane({
+  sessions,
+  disabled,
+  onSelect,
+}: {
+  sessions: MobileTerminalSessionItem[];
+  disabled: boolean;
+  onSelect?: (id: string) => void;
+}) {
+  if (sessions.length === 0) {
+    return (
+      <div className="grid h-full place-items-center px-4 text-center font-mono text-sm text-muted">
+        No sessions
+      </div>
+    );
+  }
+
+  return (
+    <div className="h-full overflow-auto p-2">
+      <div className="grid gap-1">
+        {sessions.map((session) => {
+          const active = session.active === true;
+          const ringing = session.status === 'ALERT_RINGING' || session.status === 'MIGHT_NEED_ATTENTION';
+          return (
+            <button
+              key={session.id}
+              type="button"
+              disabled={disabled}
+              aria-current={active ? 'page' : undefined}
+              onClick={() => onSelect?.(session.id)}
+              className={clsx(
+                'flex min-h-10 min-w-0 items-center gap-2 rounded px-2 text-left font-mono text-xs transition-colors',
+                'focus-visible:outline focus-visible:outline-1 focus-visible:outline-offset-1 focus-visible:outline-focus-ring',
+                'disabled:pointer-events-none disabled:opacity-60',
+                active
+                  ? 'bg-header-active-bg text-header-active-fg shadow-[inset_0_0_0_1px_var(--color-focus-ring)]'
+                  : 'bg-surface-raised text-foreground hover:bg-header-inactive-bg',
+              )}
+            >
+              <TerminalWindowIcon size={15} weight={active ? 'bold' : 'regular'} className="shrink-0" />
+              <span className="min-w-0 flex-1">
+                <span className="block truncate font-medium">{session.title}</span>
+                {session.secondary ? (
+                  <span className={clsx('block truncate', active ? 'opacity-70' : 'text-muted')}>{session.secondary}</span>
+                ) : null}
+              </span>
+              {session.todo ? (
+                <span className="shrink-0 rounded border border-current px-1 py-px text-[0.55rem] font-semibold leading-none tracking-[0.08em]">
+                  TODO
+                </span>
+              ) : null}
+              {ringing ? (
+                <BellIcon
+                  size={14}
+                  weight="fill"
+                  className={clsx(
+                    'shrink-0',
+                    active ? 'text-alarm-vs-header-active' : 'text-alarm-vs-door',
+                    bellIconClass(session.status ?? 'ALERT_RINGING'),
+                  )}
+                />
+              ) : null}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
 export function MobileTerminalUi({
   terminal,
   activeSection,
@@ -301,6 +376,8 @@ export function MobileTerminalUi({
   cursorTouchAvailable = false,
   onSendInput,
   onFocusInput,
+  sessions = [],
+  onSessionSelect,
   interactive = true,
   fillViewport = false,
   className,
@@ -497,7 +574,17 @@ export function MobileTerminalUi({
         onSelect={setKeyboardMode}
       />
 
-      <div className="h-64 shrink-0 bg-app-bg">
+      <div className="h-64 shrink-0 bg-header-inactive-bg text-header-inactive-fg">
+        {keyboardMode === 'sessions' ? (
+          <SessionsPane
+            sessions={sessions}
+            disabled={!interactive}
+            onSelect={(id) => {
+              onSessionSelect?.(id);
+              blurInput();
+            }}
+          />
+        ) : null}
         {keyboardMode === 'recent' ? <WorkInProgressPane label="Recent" /> : null}
         {keyboardMode === 'draft' ? <WorkInProgressPane label="Draft" /> : null}
         {keyboardMode === 'type' ? (
@@ -507,7 +594,7 @@ export function MobileTerminalUi({
             aria-label="Focus terminal input"
             onClick={focusInput}
             className={clsx(
-              'grid h-full w-full place-items-center bg-app-bg text-terminal-fg transition-colors',
+              'grid h-full w-full place-items-center bg-header-inactive-bg text-header-inactive-fg transition-colors',
               'focus-visible:outline focus-visible:outline-1 focus-visible:outline-inset focus-visible:outline-focus-ring',
               'disabled:pointer-events-none disabled:opacity-60',
             )}

--- a/lib/src/components/MobileTerminalUi.tsx
+++ b/lib/src/components/MobileTerminalUi.tsx
@@ -237,10 +237,16 @@ function KeyboardModeSelector({
   );
 }
 
-function WorkInProgressPane({ label }: { label: 'Recent' | 'Draft' }) {
+const RESERVE_PLACEHOLDER_COPY = {
+  recent: 'WIP - commands you have recently executed will be available here',
+  type: 'Onscreen keyboard goes here',
+  draft: 'WIP - this will be a place to draft prompts before pasting into the terminal',
+} as const;
+
+function WorkInProgressPane({ mode }: { mode: 'recent' | 'draft' }) {
   return (
     <div className="grid h-full place-items-center px-4 text-center font-mono text-sm text-muted">
-      {label} - WIP
+      {RESERVE_PLACEHOLDER_COPY[mode]}
     </div>
   );
 }
@@ -538,8 +544,8 @@ export function MobileTerminalUi({
             }}
           />
         ) : null}
-        {keyboardMode === 'recent' ? <WorkInProgressPane label="Recent" /> : null}
-        {keyboardMode === 'draft' ? <WorkInProgressPane label="Draft" /> : null}
+        {keyboardMode === 'recent' ? <WorkInProgressPane mode="recent" /> : null}
+        {keyboardMode === 'draft' ? <WorkInProgressPane mode="draft" /> : null}
         {keyboardMode === 'type' ? (
           <button
             type="button"
@@ -552,7 +558,7 @@ export function MobileTerminalUi({
               'disabled:pointer-events-none disabled:opacity-60',
             )}
           >
-            <span aria-hidden="true" className="font-mono text-3xl leading-none text-focus-ring">▌</span>
+            <span className="px-4 text-center font-mono text-sm text-muted">{RESERVE_PLACEHOLDER_COPY.type}</span>
           </button>
         ) : null}
       </div>

--- a/lib/src/components/MobileTerminalUi.tsx
+++ b/lib/src/components/MobileTerminalUi.tsx
@@ -16,14 +16,13 @@ import {
   CursorClickIcon,
   CursorTextIcon,
   HandPointingIcon,
-  KeyboardIcon,
   TerminalWindowIcon,
   TextTIcon,
 } from '@phosphor-icons/react';
 import { clsx } from 'clsx';
 import { bellIconClass } from './bell-icon-class';
 
-export type MobileTerminalKeyboardMode = 'sessions' | 'recent' | 'type' | 'draft' | 'keys';
+export type MobileTerminalKeyboardMode = 'sessions' | 'recent' | 'type' | 'draft';
 export type MobileTerminalSection = MobileTerminalKeyboardMode;
 export type MobileTerminalTouchMode = 'gestures' | 'selection' | 'cursor';
 type PhosphorIcon = ComponentType<{ size?: number; weight?: 'regular' | 'bold' | 'duotone' | 'fill' }>;
@@ -50,29 +49,11 @@ export const MOBILE_TERMINAL_KEY_SEQUENCES = {
   left: '\x1b[D',
 } as const;
 
-interface TerminalKey {
-  id: keyof typeof MOBILE_TERMINAL_KEY_SEQUENCES;
-  label: string;
-  title: string;
-}
-
-const TERMINAL_KEYS: TerminalKey[] = [
-  { id: 'esc', label: 'Esc', title: 'Escape' },
-  { id: 'tab', label: 'Tab', title: 'Tab' },
-  { id: 'space', label: 'Space', title: 'Space' },
-  { id: 'enter', label: 'Enter', title: 'Enter' },
-  { id: 'left', label: '\u2190', title: 'Left arrow' },
-  { id: 'down', label: '\u2193', title: 'Down arrow' },
-  { id: 'up', label: '\u2191', title: 'Up arrow' },
-  { id: 'right', label: '\u2192', title: 'Right arrow' },
-];
-
 const KEYBOARD_MODES: Array<{ id: MobileTerminalKeyboardMode; label: string; Icon: PhosphorIcon }> = [
   { id: 'sessions', label: 'Sessions', Icon: TerminalWindowIcon },
   { id: 'recent', label: 'Recent', Icon: ClockCounterClockwiseIcon },
   { id: 'type', label: 'Type', Icon: TextTIcon },
   { id: 'draft', label: 'Draft', Icon: ArticleNyTimesIcon },
-  { id: 'keys', label: 'Keys', Icon: KeyboardIcon },
 ];
 
 const TOUCH_MODES: Array<{
@@ -135,34 +116,6 @@ function keyDownSequence(event: KeyboardEvent<HTMLTextAreaElement>): string | nu
     default:
       return null;
   }
-}
-
-function KeyButton({
-  item,
-  disabled,
-  onPress,
-}: {
-  item: TerminalKey;
-  disabled: boolean;
-  onPress: (id: keyof typeof MOBILE_TERMINAL_KEY_SEQUENCES) => void;
-}) {
-  return (
-    <button
-      type="button"
-      title={item.title}
-      disabled={disabled}
-      onPointerDown={(event) => event.preventDefault()}
-      onClick={() => onPress(item.id)}
-      className={clsx(
-        'flex min-w-0 items-center justify-center rounded border border-border bg-surface-raised font-mono text-foreground transition-colors',
-        'hover:bg-header-inactive-bg focus-visible:outline focus-visible:outline-1 focus-visible:outline-offset-2 focus-visible:outline-focus-ring',
-        'disabled:pointer-events-none disabled:opacity-60',
-        'min-h-14 px-2 text-sm',
-      )}
-    >
-      <span className="truncate">{item.label}</span>
-    </button>
-  );
 }
 
 function KeyboardModeButton({
@@ -267,7 +220,7 @@ function KeyboardModeSelector({
       aria-label="Input mode"
       className="flex h-9 shrink-0 items-center border-t border-border bg-header-inactive-bg px-2 text-header-inactive-fg"
     >
-      <nav className="grid min-w-0 flex-1 grid-cols-[1.35fr_repeat(4,minmax(0,1fr))] gap-1 rounded bg-header-inactive-bg p-1 shadow-[inset_0_0_0_1px_var(--color-border)]">
+      <nav className="grid min-w-0 flex-1 grid-cols-[1.25fr_repeat(3,minmax(0,1fr))] gap-1 rounded bg-header-inactive-bg p-1 shadow-[inset_0_0_0_1px_var(--color-border)]">
         {KEYBOARD_MODES.map((item) => (
           <KeyboardModeButton
             key={item.id}
@@ -601,30 +554,6 @@ export function MobileTerminalUi({
           >
             <span aria-hidden="true" className="font-mono text-3xl leading-none text-focus-ring">▌</span>
           </button>
-        ) : null}
-        {keyboardMode === 'keys' ? (
-          <div className="grid h-full grid-rows-2 gap-2 p-3">
-            <div className="grid grid-cols-4 gap-2">
-              {TERMINAL_KEYS.slice(0, 4).map((item) => (
-                <KeyButton
-                  key={item.id}
-                  item={item}
-                  disabled={!interactive}
-                  onPress={(id) => sendInput(MOBILE_TERMINAL_KEY_SEQUENCES[id])}
-                />
-              ))}
-            </div>
-            <div className="grid grid-cols-4 gap-2">
-              {TERMINAL_KEYS.slice(4).map((item) => (
-                <KeyButton
-                  key={item.id}
-                  item={item}
-                  disabled={!interactive}
-                  onPress={(id) => sendInput(MOBILE_TERMINAL_KEY_SEQUENCES[id])}
-                />
-              ))}
-            </div>
-          </div>
         ) : null}
       </div>
 

--- a/lib/src/components/MobileTerminalUi.tsx
+++ b/lib/src/components/MobileTerminalUi.tsx
@@ -191,7 +191,7 @@ function KeyboardModeButton({
 
 function SelectorLabel({ children }: { children: ReactNode }) {
   return (
-    <div className="w-[4.5rem] shrink-0 pl-2 pr-1 font-mono text-xs leading-none text-muted">
+    <div className="w-12 shrink-0 pl-2 pr-1 font-mono text-xs leading-none text-muted">
       {children}
     </div>
   );
@@ -211,7 +211,7 @@ function TouchModeSelector({
   return (
     <section
       aria-label="Touch mode"
-      className="flex h-12 shrink-0 items-center border-t border-border bg-app-bg"
+      className="flex h-9 shrink-0 items-center bg-app-bg"
     >
       <SelectorLabel>Touch</SelectorLabel>
       <div className="mr-2 grid min-w-0 flex-1 grid-cols-3 gap-1 rounded bg-surface-raised p-1 shadow-[inset_0_0_0_1px_var(--color-border)]">
@@ -259,7 +259,7 @@ function KeyboardModeSelector({
   return (
     <section
       aria-label="Keyboard mode"
-      className="flex h-12 shrink-0 items-center border-t border-border bg-app-bg"
+      className="flex h-9 shrink-0 items-center border-t border-border bg-app-bg"
     >
       <SelectorLabel>Input</SelectorLabel>
       <nav className="mr-2 grid min-w-0 flex-1 grid-cols-4 gap-1 rounded bg-surface-raised p-1 shadow-[inset_0_0_0_1px_var(--color-border)]">
@@ -497,7 +497,7 @@ export function MobileTerminalUi({
         onSelect={setKeyboardMode}
       />
 
-      <div className="h-64 shrink-0 border-t border-border bg-app-bg">
+      <div className="h-64 shrink-0 bg-app-bg">
         {keyboardMode === 'recent' ? <WorkInProgressPane label="Recent" /> : null}
         {keyboardMode === 'draft' ? <WorkInProgressPane label="Draft" /> : null}
         {keyboardMode === 'type' ? (

--- a/lib/src/components/MobileWall.tsx
+++ b/lib/src/components/MobileWall.tsx
@@ -1,0 +1,249 @@
+import { useCallback, useEffect, useMemo, useState, useSyncExternalStore } from 'react';
+import {
+  ArrowLineDownIcon,
+  BellIcon,
+  BellSlashIcon,
+  XIcon,
+} from '@phosphor-icons/react';
+import { HeaderActionButton } from './HeaderActionButton';
+import { TerminalPane } from './TerminalPane';
+import { bellIconClass } from './bell-icon-class';
+import { TODO_PILL_TRACKING_CLASS } from './design';
+import { useTodoPillContent } from './TodoPillBody';
+import type { MobileTerminalSessionItem } from './MobileTerminalUi';
+import {
+  clearSessionTodo,
+  DEFAULT_ACTIVITY_STATE,
+  dismissOrToggleAlert,
+  disposeSession,
+  getActivitySnapshot,
+  getOrCreateTerminal,
+  getTerminalPaneStateSnapshot,
+  setTerminalUserTitle,
+  subscribeToActivity,
+  subscribeToTerminalPaneState,
+  type SessionStatus,
+} from '../lib/terminal-registry';
+import {
+  buildAppTitleResolver,
+  createTerminalPaneState,
+  DEFAULT_IDLE_TITLE,
+  deriveHeader,
+  resolveDisplayPrimary,
+} from '../lib/terminal-state';
+
+export interface MobileWallSession {
+  id: string;
+  title?: string;
+}
+
+export interface MobileWallProps {
+  sessions?: MobileWallSession[];
+  activeSessionId?: string;
+  defaultActiveSessionId?: string;
+  onActiveSessionChange?: (id: string) => void;
+  onSessionMinimize?: (id: string) => void;
+  onSessionKill?: (id: string) => void;
+  className?: string;
+}
+
+const DEFAULT_MOBILE_SESSION: MobileWallSession = { id: 'mobile-pane' };
+
+const ALERT_BUTTON_LABELS: Record<SessionStatus, { aria: string; tooltip: string }> = {
+  ALERT_DISABLED: { aria: 'Enable alert', tooltip: 'Enable alerts' },
+  NOTHING_TO_SHOW: { aria: 'Disable alert', tooltip: 'Disable alerts' },
+  MIGHT_BE_BUSY: { aria: 'Disable alert', tooltip: 'Disable alerts' },
+  BUSY: { aria: 'Disable alert', tooltip: 'Disable alerts' },
+  MIGHT_NEED_ATTENTION: { aria: 'Disable alert', tooltip: 'Disable alerts' },
+  ALERT_RINGING: { aria: 'Alert ringing', tooltip: 'Alert ringing' },
+  OSC_NOTIF_BUSY: { aria: 'Progress active', tooltip: 'Progress active' },
+};
+
+export function useMobileWallSessionItems(
+  sessions: MobileWallSession[],
+  activeSessionId: string | null,
+): MobileTerminalSessionItem[] {
+  const activityStates = useSyncExternalStore(subscribeToActivity, getActivitySnapshot, getActivitySnapshot);
+  const terminalStates = useSyncExternalStore(subscribeToTerminalPaneState, getTerminalPaneStateSnapshot, getTerminalPaneStateSnapshot);
+  const allSessionStates = useMemo(
+    () => sessions.map((session) => terminalStates.get(session.id) ?? createTerminalPaneState()),
+    [sessions, terminalStates],
+  );
+  const visiblePaneStates = allSessionStates.length > 0 ? allSessionStates : [createTerminalPaneState()];
+  const appTitleForPane = useMemo(
+    () => buildAppTitleResolver(terminalStates, activityStates),
+    [terminalStates, activityStates],
+  );
+
+  return useMemo(() => sessions.map((session) => {
+    const paneState = terminalStates.get(session.id) ?? createTerminalPaneState();
+    const activity = activityStates.get(session.id) ?? DEFAULT_ACTIVITY_STATE;
+    const derivedHeader = deriveHeader(paneState, visiblePaneStates, { appTitleForPane });
+    const primary = resolveDisplayPrimary(derivedHeader.primary, session.title);
+    return {
+      id: session.id,
+      title: primary === DEFAULT_IDLE_TITLE && session.title ? session.title : primary,
+      secondary: derivedHeader.secondary,
+      active: session.id === activeSessionId,
+      status: activity.status,
+      todo: activity.todo,
+    };
+  }), [activeSessionId, activityStates, appTitleForPane, sessions, terminalStates, visiblePaneStates]);
+}
+
+export function MobileWall({
+  sessions: controlledSessions,
+  activeSessionId,
+  defaultActiveSessionId,
+  onActiveSessionChange,
+  onSessionMinimize,
+  onSessionKill,
+  className,
+}: MobileWallProps) {
+  const [internalSessions, setInternalSessions] = useState<MobileWallSession[]>(() => controlledSessions ?? [DEFAULT_MOBILE_SESSION]);
+  const sessions = controlledSessions ?? internalSessions;
+  const firstSessionId = sessions[0]?.id ?? null;
+  const [internalActiveSessionId, setInternalActiveSessionId] = useState<string | null>(defaultActiveSessionId ?? firstSessionId);
+  const resolvedActiveSessionId = activeSessionId ?? internalActiveSessionId ?? firstSessionId;
+  const sessionItems = useMobileWallSessionItems(sessions, resolvedActiveSessionId);
+  const activeItem = sessionItems.find((session) => session.id === resolvedActiveSessionId) ?? sessionItems[0] ?? null;
+
+  const selectSession = useCallback((id: string) => {
+    if (activeSessionId === undefined) setInternalActiveSessionId(id);
+    onActiveSessionChange?.(id);
+  }, [activeSessionId, onActiveSessionChange]);
+
+  const killSession = useCallback((id: string) => {
+    disposeSession(id);
+    onSessionKill?.(id);
+    if (controlledSessions) {
+      const fallback = sessions.find((session) => session.id !== id)?.id ?? null;
+      if (fallback && id === resolvedActiveSessionId) selectSession(fallback);
+      return;
+    }
+
+    setInternalSessions((current) => {
+      const next = current.filter((session) => session.id !== id);
+      const fallback = next[0]?.id ?? null;
+      if (id === resolvedActiveSessionId) setInternalActiveSessionId(fallback);
+      return next;
+    });
+  }, [controlledSessions, onSessionKill, resolvedActiveSessionId, selectSession, sessions]);
+
+  useEffect(() => {
+    for (const session of sessions) {
+      getOrCreateTerminal(session.id);
+      if (session.title) setTerminalUserTitle(session.id, session.title);
+    }
+  }, [sessions]);
+
+  useEffect(() => {
+    if (!resolvedActiveSessionId && firstSessionId) {
+      selectSession(firstSessionId);
+      return;
+    }
+    if (resolvedActiveSessionId && !sessions.some((session) => session.id === resolvedActiveSessionId) && firstSessionId) {
+      selectSession(firstSessionId);
+    }
+  }, [firstSessionId, resolvedActiveSessionId, selectSession, sessions]);
+
+  if (!activeItem) {
+    return (
+      <div className={`grid h-full place-items-center bg-app-bg font-mono text-sm text-muted ${className ?? ''}`}>
+        No sessions
+      </div>
+    );
+  }
+
+  return (
+    <div className={`flex h-full min-h-0 flex-col overflow-hidden bg-app-bg ${className ?? ''}`}>
+      <MobileWallHeader
+        session={activeItem}
+        onMinimize={() => onSessionMinimize?.(activeItem.id)}
+        onKill={() => killSession(activeItem.id)}
+      />
+      <div className="min-h-0 flex-1 overflow-hidden bg-terminal-bg">
+        <TerminalPane id={activeItem.id} isFocused />
+      </div>
+    </div>
+  );
+}
+
+function MobileWallHeader({
+  session,
+  onMinimize,
+  onKill,
+}: {
+  session: MobileTerminalSessionItem;
+  onMinimize: () => void;
+  onKill: () => void;
+}) {
+  const status = session.status ?? 'ALERT_DISABLED';
+  const todoPill = useTodoPillContent(session.todo === true);
+  const alertButtonLabels = ALERT_BUTTON_LABELS[status];
+  const showTodoPill = todoPill.visible;
+
+  return (
+    <div className="flex h-8 shrink-0 items-center gap-1.5 bg-header-active-bg pl-2 pr-[5px] font-mono text-sm leading-none text-header-active-fg">
+      <div className="flex min-w-0 flex-1 items-center gap-1.5">
+        <span className="min-w-0 shrink truncate font-medium">{session.title}</span>
+        <HeaderActionButton
+          className={[
+            'flex h-5 min-w-5 items-center justify-center rounded transition-colors shrink-0 hover:bg-current/10',
+            status === 'ALERT_RINGING' ? 'text-alarm-vs-header-active' : '',
+          ].join(' ')}
+          onClick={() => dismissOrToggleAlert(session.id, status)}
+          ariaLabel={alertButtonLabels.aria}
+          tooltip={alertButtonLabels.tooltip}
+          tooltipAlign="left"
+          dataAlertButtonFor={session.id}
+        >
+          <span className="flex items-center justify-center">
+            {status === 'ALERT_DISABLED' ? (
+              <BellSlashIcon size={14} />
+            ) : (
+              <BellIcon size={14} weight="fill" className={bellIconClass(status)} />
+            )}
+          </span>
+        </HeaderActionButton>
+        {session.secondary ? (
+          <span className="min-w-0 shrink truncate opacity-70">{session.secondary}</span>
+        ) : null}
+      </div>
+      {showTodoPill ? (
+        <button
+          type="button"
+          data-session-todo-for={session.id}
+          data-flourishing={todoPill.flourishing ? 'true' : 'false'}
+          className={`todo-pill-shell shrink-0 rounded border border-current px-1.5 py-px text-xs font-semibold ${TODO_PILL_TRACKING_CLASS} transition-colors hover:bg-current/10 focus:outline-none`}
+          aria-label="Dismiss TODO"
+          aria-hidden={todoPill.flourishing ? true : undefined}
+          onClick={(event) => {
+            event.stopPropagation();
+            clearSessionTodo(session.id);
+          }}
+        >
+          {todoPill.body}
+        </button>
+      ) : null}
+      <div className="ml-1 flex shrink-0 items-center gap-0.5">
+        <HeaderActionButton
+          className="flex h-5 min-w-5 items-center justify-center rounded transition-colors hover:bg-current/10"
+          onClick={onMinimize}
+          ariaLabel="Minimize"
+          tooltip="Minimize"
+        >
+          <ArrowLineDownIcon size={14} />
+        </HeaderActionButton>
+        <HeaderActionButton
+          className="flex h-5 min-w-5 items-center justify-center rounded transition-colors hover:bg-error/10 hover:text-error"
+          onClick={onKill}
+          ariaLabel="Kill"
+          tooltip="Kill"
+        >
+          <XIcon size={14} />
+        </HeaderActionButton>
+      </div>
+    </div>
+  );
+}

--- a/lib/src/stories/MobileTerminalUi.stories.tsx
+++ b/lib/src/stories/MobileTerminalUi.stories.tsx
@@ -153,13 +153,6 @@ export const TypePane: Story = {
   render: (args) => <StoryFrame {...args} />,
 };
 
-export const KeysPane: Story = {
-  args: {
-    defaultSection: 'keys',
-  },
-  render: (args) => <StoryFrame {...args} />,
-};
-
 export const RecentTodoPane: Story = {
   args: {
     defaultSection: 'recent',
@@ -184,7 +177,7 @@ export const NonInteractivePhoneMockup: Story = {
 
 export const CursorTouchAvailable: Story = {
   args: {
-    defaultSection: 'keys',
+    defaultSection: 'type',
     cursorTouchAvailable: true,
   },
   render: (args) => <StoryFrame {...args} />,

--- a/lib/src/stories/MobileTerminalUi.stories.tsx
+++ b/lib/src/stories/MobileTerminalUi.stories.tsx
@@ -1,10 +1,18 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { useMemo, useState } from 'react';
+import { useMemo, useRef, useState } from 'react';
 import {
   MOBILE_TERMINAL_KEY_SEQUENCES,
   MobileTerminalUi,
+  type MobileTerminalKeyboardMode,
   type MobileTerminalUiProps,
 } from '../components/MobileTerminalUi';
+import { MobileWall, useMobileWallSessionItems, type MobileWallSession } from '../components/MobileWall';
+import {
+  flattenScenario,
+  initPlatform,
+  type FakePtyAdapter,
+  type FakeScenario,
+} from '../lib/platform';
 
 const meta: Meta<typeof MobileTerminalUi> = {
   title: 'App/MobileTerminalUi',
@@ -16,6 +24,30 @@ const meta: Meta<typeof MobileTerminalUi> = {
 
 export default meta;
 type Story = StoryObj<typeof MobileTerminalUi>;
+
+const TETHER_WALL_PANE = 'storybook-tether-wall';
+const TETHER_WALL_SESSIONS: MobileWallSession[] = [{ id: TETHER_WALL_PANE, title: 'ascii-splash' }];
+
+const TETHER_WALL_SCENARIO: FakeScenario = {
+  name: 'tether-wall-ascii-splash',
+  chunks: [{
+    delay: 0,
+    data: [
+      '\x1b[32mascii-splash\x1b[0m\r\n',
+      '\x1b[2mpattern=oceanbeach quality=medium fps=30\x1b[0m\r\n',
+      '\r\n',
+      '\r\n',
+      '\r\n',
+      '                 ~~~~~ * ~~~~~\r\n',
+      '                   ~~~~ /|\\ ~~~~\r\n',
+      '                 ~~~~ /_|_\\ ~~~~\r\n',
+      '                   ~~~~ / \\ ~~~~\r\n',
+      '\r\n',
+      '\r\n',
+      '$ _',
+    ].join(''),
+  }],
+};
 
 const SEQUENCE_LABELS = new Map<string, string>([
   [MOBILE_TERMINAL_KEY_SEQUENCES.ctrlC, 'CTRL_C'],
@@ -75,6 +107,45 @@ function StoryFrame(args: MobileTerminalUiProps) {
   );
 }
 
+function TetherWallFrame(args: MobileTerminalUiProps) {
+  const adapterRef = useRef<FakePtyAdapter | null>(null);
+  if (!adapterRef.current) adapterRef.current = initPlatform('fake');
+  const [activePaneId, setActivePaneId] = useState(TETHER_WALL_PANE);
+  const [keyboardMode, setKeyboardMode] = useState<MobileTerminalKeyboardMode>(
+    args.activeKeyboardMode ?? args.activeSection ?? args.defaultKeyboardMode ?? args.defaultSection ?? 'type',
+  );
+  const sessionItems = useMobileWallSessionItems(TETHER_WALL_SESSIONS, activePaneId);
+
+  return (
+    <main className="fixed inset-0 bg-black">
+      <MobileTerminalUi
+        {...args}
+        fillViewport
+        terminal={(
+          <MobileWall
+            sessions={TETHER_WALL_SESSIONS}
+            activeSessionId={activePaneId}
+            onActiveSessionChange={setActivePaneId}
+            onSessionMinimize={() => setKeyboardMode('sessions')}
+          />
+        )}
+        activeKeyboardMode={keyboardMode}
+        onKeyboardModeChange={(mode) => {
+          setKeyboardMode(mode);
+          args.onKeyboardModeChange?.(mode);
+          args.onSectionChange?.(mode);
+        }}
+        sessions={sessionItems}
+        onSessionSelect={setActivePaneId}
+        onSendInput={(data) => {
+          args.onSendInput?.(data);
+          adapterRef.current?.writePty(activePaneId, data);
+        }}
+      />
+    </main>
+  );
+}
+
 export const TypePane: Story = {
   args: {
     defaultSection: 'type',
@@ -117,4 +188,15 @@ export const CursorTouchAvailable: Story = {
     cursorTouchAvailable: true,
   },
   render: (args) => <StoryFrame {...args} />,
+};
+
+export const TetherWall: Story = {
+  args: {
+    defaultSection: 'type',
+  },
+  parameters: {
+    layout: 'fullscreen',
+    fakePty: { scenario: flattenScenario(TETHER_WALL_SCENARIO) },
+  },
+  render: (args) => <TetherWallFrame {...args} />,
 };

--- a/website/src/pages/Tether.tsx
+++ b/website/src/pages/Tether.tsx
@@ -2,7 +2,8 @@ import { useCallback, useEffect, useRef, useState, useSyncExternalStore } from "
 import { ShareIcon } from "@phosphor-icons/react";
 import SiteHeader, { STATIC_PAGE_HEADER_STYLE } from "../components/SiteHeader";
 import { NotifySignupForm } from "../components/NotifySignupForm";
-import { MobileTerminalUi, type MobileTerminalTouchMode } from "mouseterm-lib/components/MobileTerminalUi";
+import { MobileTerminalUi, type MobileTerminalKeyboardMode, type MobileTerminalTouchMode } from "mouseterm-lib/components/MobileTerminalUi";
+import { MobileWall, useMobileWallSessionItems, type MobileWallSession } from "mouseterm-lib/components/MobileWall";
 import { ThemePicker } from "mouseterm-lib/components/ThemePicker";
 import { restoreActiveTheme } from "mouseterm-lib/lib/themes";
 import {
@@ -21,19 +22,7 @@ type FakePtyAdapter = import("mouseterm-lib/lib/platform/fake-adapter").FakePtyA
 
 const TETHER_PANE = "tether-ascii-splash";
 const TETHER_THEME_ID = "vscode.theme-kimbie-dark.kimbie-dark";
-
-interface WallModule {
-  Wall: typeof import("mouseterm-lib/components/Wall")["Wall"];
-}
-
-interface DockviewApiLike {
-  activePanel?: { id?: string } | null;
-  getPanel(id: string): { api: { setTitle(title: string): void; setActive(): void } } | undefined;
-  onDidAddPanel(listener: (panel: { id?: string } | undefined) => void): { dispose: () => void };
-  onDidActivePanelChange(listener: (panel: { id?: string } | undefined) => void): { dispose: () => void };
-}
-
-type DockviewDisposable = { dispose: () => void };
+const TETHER_SESSIONS: MobileWallSession[] = [{ id: TETHER_PANE, title: "ascii-splash" }];
 
 function useIsMobileViewport() {
   const [isMobile, setIsMobile] = useState(false);
@@ -65,15 +54,16 @@ function TetherTerminalExperience({
   fillViewport?: boolean;
 }) {
   useTetherTheme();
-  const [WallModule, setWallModule] = useState<WallModule | null>(null);
+  const [terminalReady, setTerminalReady] = useState(false);
   const adapterRef = useRef<FakePtyAdapter | null>(null);
   const shellRegistryRef = useRef<PlaygroundShellRegistry | null>(null);
-  const dockviewDisposablesRef = useRef<DockviewDisposable[]>([]);
   const autoStartedRef = useRef<Set<string>>(new Set());
   const spawnUnsubRef = useRef<(() => void) | null>(null);
   const busyDemoDisposeRef = useRef<(() => void) | null>(null);
   const [activePaneId, setActivePaneId] = useState(TETHER_PANE);
   const [touchMode, setTouchMode] = useState<MobileTerminalTouchMode>("gestures");
+  const [keyboardMode, setKeyboardMode] = useState<MobileTerminalKeyboardMode>("type");
+  const sessionItems = useMobileWallSessionItems(TETHER_SESSIONS, activePaneId);
   const mouseStates = useSyncExternalStore(
     subscribeToMouseSelection,
     getMouseSelectionSnapshot,
@@ -98,7 +88,6 @@ function TetherTerminalExperience({
     async function loadWall() {
       const platform = await import("mouseterm-lib/lib/platform");
       const registry = await import("mouseterm-lib/lib/terminal-registry");
-      const wall = await import("mouseterm-lib/components/Wall");
       const scenarios = await import("mouseterm-lib/lib/platform/fake-scenarios");
       const asciiSplash = await import("../lib/ascii-splash-runner");
       await import("mouseterm-lib/index.css");
@@ -156,17 +145,13 @@ function TetherTerminalExperience({
       });
       if (adapter.hasPty(TETHER_PANE)) tryAutoStart(TETHER_PANE);
 
-      setWallModule({ Wall: wall.Wall });
+      setTerminalReady(true);
     }
 
     loadWall();
 
     return () => {
       cancelled = true;
-      for (const disposable of dockviewDisposablesRef.current) {
-        disposable.dispose();
-      }
-      dockviewDisposablesRef.current = [];
       spawnUnsubRef.current?.();
       spawnUnsubRef.current = null;
       busyDemoDisposeRef.current?.();
@@ -187,35 +172,15 @@ function TetherTerminalExperience({
     }
   }, [activeMouseState?.mouseReporting, activePaneId, touchMode]);
 
-  const handleApiReady = useCallback((api: DockviewApiLike) => {
-    const addDisposable = api.onDidAddPanel((panel) => {
-      if (panel?.id) shellRegistryRef.current?.ensureShell(panel.id);
-    });
-    dockviewDisposablesRef.current.push(addDisposable);
-
-    const activeDisposable = api.onDidActivePanelChange((panel) => {
-      if (panel?.id) setActivePaneId(panel.id);
-    });
-    dockviewDisposablesRef.current.push(activeDisposable);
-
-    setActivePaneId(api.activePanel?.id ?? TETHER_PANE);
-    shellRegistryRef.current?.ensureShell(TETHER_PANE);
-
-    const panel = api.getPanel(TETHER_PANE);
-    if (!panel) return;
-    panel.api.setTitle("ascii-splash");
-    panel.api.setActive();
-  }, []);
-
   return (
     <MobileTerminalUi
       terminal={
-        WallModule ? (
-          <WallModule.Wall
-            initialPaneIds={[TETHER_PANE]}
-            initialMode="passthrough"
-            onApiReady={handleApiReady}
-            showBaseboard={false}
+        terminalReady ? (
+          <MobileWall
+            sessions={TETHER_SESSIONS}
+            activeSessionId={activePaneId}
+            onActiveSessionChange={setActivePaneId}
+            onSessionMinimize={() => setKeyboardMode("sessions")}
           />
         ) : null
       }
@@ -223,7 +188,11 @@ function TetherTerminalExperience({
       fillViewport={fillViewport}
       activeTouchMode={touchMode}
       onTouchModeChange={setTouchMode}
+      activeKeyboardMode={keyboardMode}
+      onKeyboardModeChange={setKeyboardMode}
       cursorTouchAvailable={cursorTouchAvailable}
+      sessions={sessionItems}
+      onSessionSelect={setActivePaneId}
       onSendInput={(data) => adapterRef.current?.writePty(activePaneId, data)}
     />
   );


### PR DESCRIPTION
## Summary
- Update the mobile terminal UI to use the new `Touch`/`Input` row structure with `Mouse` naming, adjusted spacing, and the `Sessions` reserve mode
- Add the mobile gesture radial menu and wire it into the mobile wall experience
- Bring the `/tether` page and Storybook stories in line with the mobile-only wall flow
- Update `docs/specs/mobile-ui.md` to match the revised mobile layout and interaction model

## Testing
- `pnpm --filter mouseterm-lib build`
- `pnpm --filter mouseterm-website build`
- `pnpm --filter mouseterm-lib test`
- Verified the `MobileTerminalUi` Storybook story for the mobile wall visually in the browser