### PR TITLE
Rename standalone app to "Dormouse Terminal" so it's findable by "Term"

### DIFF
--- a/docs/specs/deploy.md
+++ b/docs/specs/deploy.md
@@ -123,7 +123,7 @@ codesign/jsign the executable
 
 ### Packaged app logging
 
-Windows release builds use the GUI subsystem, so launching `dormouse.exe` from a terminal returns immediately and does not stream stdout/stderr. The Tauri backend writes sidecar diagnostics to `%LOCALAPPDATA%\Dormouse\dormouse.log` on Windows, or to `$TMPDIR/dormouse.log` on other platforms. Set `DORMOUSE_LOG_FILE` to override the path.
+Windows release builds use the GUI subsystem, so launching `dormouse.exe` from a terminal returns immediately and does not stream stdout/stderr. The Tauri backend writes sidecar diagnostics to `%LOCALAPPDATA%\Dormouse Terminal\dormouse.log` on Windows, or to `$TMPDIR/dormouse.log` on other platforms. Set `DORMOUSE_LOG_FILE` to override the path.
 
 ## Artifact filenames
 

--- a/scripts/sign-and-deploy.sh
+++ b/scripts/sign-and-deploy.sh
@@ -154,7 +154,7 @@ require_single_find_match() {
 mac_app_path() {
     require_directory \
         "macOS app bundle" \
-        "$SIGN_DIR/standalone-mac-aarch64/src-tauri/target/aarch64-apple-darwin/release/bundle/macos/Dormouse.app"
+        "$SIGN_DIR/standalone-mac-aarch64/src-tauri/target/aarch64-apple-darwin/release/bundle/macos/Dormouse Terminal.app"
 }
 
 windows_release_dir() {
@@ -169,9 +169,9 @@ windows_exe_path() {
 
 windows_installer_path() {
     local version="${1:-}"
-    local pattern="Dormouse_*_x64-setup.exe"
+    local pattern="Dormouse Terminal_*_x64-setup.exe"
     if [[ -n "$version" ]]; then
-        pattern="Dormouse_${version}_x64-setup.exe"
+        pattern="Dormouse Terminal_${version}_x64-setup.exe"
     fi
 
     require_single_find_match \
@@ -188,7 +188,7 @@ linux_appimage_path() {
         "Linux AppImage" \
         "$SIGN_DIR/standalone-linux-x64/src-tauri/target/x86_64-unknown-linux-gnu/release/bundle/appimage" \
         -type f \
-        -name "Dormouse_${version}_amd64.AppImage"
+        -name "Dormouse Terminal_${version}_amd64.AppImage"
 }
 
 nsis_script_path() {

--- a/standalone/scripts/dogfood.sh
+++ b/standalone/scripts/dogfood.sh
@@ -41,11 +41,11 @@ if [[ "${1:-}" == "--install" ]]; then
   # Platform-specific: copy built files to system install location
   case "$(uname -s)" in
     MINGW*|MSYS*|CYGWIN*|Windows_NT)
-      INSTALL_DIR="$LOCALAPPDATA/Dormouse"
+      INSTALL_DIR="$LOCALAPPDATA/Dormouse Terminal"
       if [[ ! -f "$INSTALL_DIR/uninstall.exe" ]]; then
         echo "Dormouse is not installed yet."
         echo "Run the installer once first:"
-        echo "  $RELEASE_DIR/bundle/nsis/Dormouse_*-setup.exe"
+        echo "  $RELEASE_DIR/bundle/nsis/Dormouse Terminal_*-setup.exe"
         echo ""
         echo "After that, 'dogfood:standalone --install' will work from then on."
         exit 1
@@ -57,7 +57,7 @@ if [[ "${1:-}" == "--install" ]]; then
       # and `//T` would then cascade and kill us. Filter by image path so we
       # only target processes loaded from the install dir.
       powershell.exe -NoProfile -Command \
-        "Get-Process -Name dormouse,node -EA SilentlyContinue | Where-Object Path -Like '$LOCALAPPDATA\\Dormouse\\*' | Stop-Process -Force -EA SilentlyContinue" \
+        "Get-Process -Name dormouse,node -EA SilentlyContinue | Where-Object Path -Like '$LOCALAPPDATA\\Dormouse Terminal\\*' | Stop-Process -Force -EA SilentlyContinue" \
         >/dev/null 2>&1 || true
       # Wipe install-dir contents except uninstall.exe (managed by NSIS).
       # We delete *contents* rather than the directory itself so we don't trip
@@ -71,17 +71,17 @@ if [[ "${1:-}" == "--install" ]]; then
       echo "✦ Installed to $INSTALL_DIR"
       ;;
     Darwin)
-      INSTALL_DIR="/Applications/Dormouse.app"
+      INSTALL_DIR="/Applications/Dormouse Terminal.app"
       if [[ ! -d "$INSTALL_DIR" ]]; then
         echo "Dormouse is not installed yet."
         echo "Install via the DMG first:"
-        echo "  open $RELEASE_DIR/bundle/dmg/Dormouse_*.dmg"
+        echo "  open $RELEASE_DIR/bundle/dmg/Dormouse Terminal_*.dmg"
         echo ""
         echo "After that, 'dogfood:standalone --install' will work from then on."
         exit 1
       fi
       rm -rf "$INSTALL_DIR"
-      cp -r "$RELEASE_DIR/bundle/macos/Dormouse.app" "$INSTALL_DIR"
+      cp -r "$RELEASE_DIR/bundle/macos/Dormouse Terminal.app" "$INSTALL_DIR"
       echo "✦ Installed to $INSTALL_DIR"
       ;;
     *)

--- a/standalone/src-tauri/src/lib.rs
+++ b/standalone/src-tauri/src/lib.rs
@@ -54,7 +54,7 @@ fn default_log_path() -> PathBuf {
     #[cfg(target_os = "windows")]
     if let Some(local_app_data) = env::var_os("LOCALAPPDATA") {
         return PathBuf::from(local_app_data)
-            .join("Dormouse")
+            .join("Dormouse Terminal")
             .join("dormouse.log");
     }
 

--- a/standalone/src-tauri/tauri.conf.json
+++ b/standalone/src-tauri/tauri.conf.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
-  "productName": "Dormouse",
+  "productName": "Dormouse Terminal",
+  "mainBinaryName": "dormouse",
   "version": "0.10.2",
   "identifier": "sh.dormouse.standalone",
   "build": {
@@ -12,7 +13,7 @@
   "app": {
     "windows": [
       {
-        "title": "Dormouse",
+        "title": "Dormouse Terminal",
         "titleBarStyle": "Overlay",
         "hiddenTitle": true,
         "width": 1200,

--- a/website/src/pages/Home.tsx
+++ b/website/src/pages/Home.tsx
@@ -140,8 +140,8 @@ const INSTALL_STEPS: Record<string, { pill: string; title: string; steps: string
     pill: "Mac Silicon",
     title: "Installing on Mac",
     steps: [
-      "Double-click the downloaded .tar.gz to extract Dormouse.app",
-      "Drag Dormouse.app to Applications",
+      "Double-click the downloaded .tar.gz to extract Dormouse Terminal.app",
+      "Drag Dormouse Terminal.app to Applications",
     ],
   },
   "windows-x86_64": {


### PR DESCRIPTION
## What

Renames the standalone app to **"Dormouse Terminal"** so it appears under that name in the Windows Start menu and the macOS launcher/Spotlight — letting users find it by typing "Term".

## How

- **`tauri.conf.json`** — `productName` → `"Dormouse Terminal"`. This single field drives the Windows Start-menu shortcut name, the macOS `.app` bundle name (`CFBundleName`/`CFBundleDisplayName`), the install dir, and the installer artifact names.
- Pinned **`mainBinaryName: "dormouse"`** so the executable basename stays `dormouse(.exe)` regardless of `productName`. Every script reference (`dormouse.exe`, `target/release/dormouse`, `Get-Process -Name dormouse`) depends on this. The bundle identifier (`sh.dormouse.standalone`) is unchanged, so this stays an in-place update rather than a new app identity.
- Updated the window `title` to match.
- Fixed the `productName`-derived bundle/install paths in `sign-and-deploy.sh` and `dogfood.sh` (`.app`, NSIS `setup.exe`, `.dmg`, `.AppImage`, and the `%LOCALAPPDATA%` install dir), plus the hardcoded log directory in `lib.rs` and its mention in `deploy.md`.

The stable public download filenames (`FNAME_*` / `standalone-latest.json`) are intentionally decoupled from `productName` and left unchanged.

## Notes

- **Spaces in paths are fine.** They only appear in bundle/install names (normal on both OSes — `Program Files`, `Visual Studio Code.app`); the executable stays space-free thanks to `mainBinaryName`, and all derived script paths are quoted.
- **Migration:** on the rename release, the macOS updater swaps `Dormouse.app` → `Dormouse Terminal.app` and Windows installs to a new dir, so existing users may see a stale old shortcut/install until a clean reinstall. Worth a CHANGELOG note at release time.

## Testing

Not built here — full Tauri bundles can't be exercised on this machine, and the macOS/Linux paths can't be verified on Windows. Naming is confirmed by logic: the existing globs matched the old `productName` of `"Dormouse"`, proving Tauri derives these artifact names from `productName`. The next CI release build is the real verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
