### PR TITLE
dor agent-browser: browser-chrome header (nav + URL + dev-server link)

### DIFF
--- a/docs/specs/dor-agent-browser.md
+++ b/docs/specs/dor-agent-browser.md
@@ -205,10 +205,16 @@ Mechanics & wrinkles:
   localhost-reachable bind — loopback (`127.0.0.1` / `::1`) **or** any-interface
   (`0.0.0.0` / `::`, which still answers `localhost`). A bind on one specific
   non-loopback interface does not match.
-- **Cost.** `getOpenPorts` has a ~3s timeout, so the correlation runs **only
-  while a loopback port is on screen** — promptly when a header first shows one,
-  then on a slow (~5s) refresh — and at most one sweep is in flight. Visible
-  panes and minimized doors are both scanned (both keep live ptys).
+- **Cost — strictly off the hot path.** `getOpenPorts` shells out (`lsof` /
+  PowerShell) on the host that also drives the screencast, so a scan never runs
+  synchronously on tab-open: it's **debounced + idle-scheduled**
+  (`requestIdleCallback`) so the opening tab's first screenshots come first. It
+  **scans once, then settles** — a matched port is remembered and not rescanned;
+  we only keep retrying (slow idle poll) while a wanted port is still *unmatched*
+  (the dev server may start after the tab). A **surface reload** un-settles and
+  re-validates, but optimistically — the current chip stays until the rescan
+  disagrees. At most one scan is in flight; visible panes and minimized doors are
+  both scanned (both keep live ptys).
 - **Fallbacks (degrade to just the URL):** non-loopback URL; no pane listening on
   the port; a bind on a specific non-loopback interface; a tunneled/proxied
   domain; or two+ panes claiming the port (ambiguous).

--- a/docs/specs/dor-agent-browser.md
+++ b/docs/specs/dor-agent-browser.md
@@ -176,6 +176,14 @@ existing screen controller's separate **chrome snapshot** channel (URL / key),
 kept distinct from the screen snapshot so tab updates don't churn the
 SYNCED/SCALED chip and vice versa.
 
+**Click to navigate.** Clicking the URL opens an inline editor (the
+terminal-rename pattern) pre-filled with the full URL, all selected: **Enter**
+navigates (`open <url>`, scheme-normalized — `http://` for loopback so a bare
+`localhost:5173` doesn't SSL-error, `https://` otherwise); **Escape**/blur
+cancels, browser-omnibox style. While it's open the surface flags
+dialog-keyboard so the Wall's chord handler stands down, and the panel's
+key-forwarder skips editable targets so keystrokes reach the field, not the page.
+
 ### `--key` badge
 
 The `--key` (default `default`) is what `dor ab --key …` targets, so with two or
@@ -482,10 +490,10 @@ hosts degrade gracefully:
 
 - **`agentBrowserCommand(session, args)`** — runs the user's agent-browser
   binary for tab actions (`tab <n>`, `tab close`, `tab new`), screen-mode
-  resizing (`set viewport`, `set device`), history nav (`reload`, `back`,
-  `forward`), and lifecycle (`close`). The host validates `args[0]` against an
-  allowlist (`tab`, `set`, `screenshot`, `reload`, `back`, `forward`, `close`);
-  this is not a general exec channel.
+  resizing (`set viewport`, `set device`), navigation (`open <url>`, `reload`,
+  `back`, `forward`), and lifecycle (`close`). The host validates `args[0]`
+  against an allowlist (`tab`, `set`, `screenshot`, `open`, `reload`, `back`,
+  `forward`, `close`); this is not a general exec channel.
 - **`agentBrowserScreenshot(session, { format, quality })`** — captures one
   device-resolution frame via `agent-browser screenshot` (which honors the
   session DPR, unlike the screencast) and returns the raw bytes (a `Uint8Array`

--- a/docs/specs/dor-agent-browser.md
+++ b/docs/specs/dor-agent-browser.md
@@ -172,9 +172,9 @@ The header's primary text is the active tab's **URL (host + path)**; the HTML
 The persisted panel title (door labels, session save) stays the tab's display
 title — the URL preference is a live-header concern only, so the multi-tab strip
 still shows HTML titles to tell tabs apart. Both flow body→header through the
-existing screen controller's separate **chrome snapshot** channel (URL / key /
-connection), kept distinct from the screen snapshot so tab/status updates don't
-churn the SYNCED/SCALED chip and vice versa.
+existing screen controller's separate **chrome snapshot** channel (URL / key),
+kept distinct from the screen snapshot so tab updates don't churn the
+SYNCED/SCALED chip and vice versa.
 
 ### `--key` badge
 

--- a/docs/specs/dor-agent-browser.md
+++ b/docs/specs/dor-agent-browser.md
@@ -132,6 +132,100 @@ Tab behaviors:
   matching typical browser foregrounding; reversible by clicking back. Dormouse
   does not fight the web's popup / open-in-new-tab behavior.
 
+## Browser-Chrome Header
+
+The browser surface's header reads like a browser: the active tab's **URL** (not
+its HTML `<title>`), Chrome-style nav controls, and the one thing only Dormouse
+can show — which pane in the workspace is serving a localhost URL. All of this is
+**browser-surface only**, gated on the screen-controller presence exactly like
+the SYNCED/SCALED chip; terminals and iframes keep their plain title header. The
+header is shared (`SurfacePaneHeader.tsx`) and already tight and responsive.
+
+### Layout — mirror Chrome's toolbar
+
+Left→right, matching a real browser so it reads as "browser-ish":
+
+```
+┌──────────────────────────────────────────────────────────────────────────────┐
+│ ⤢   ←  →  ⟳    (storybook) localhost:5173   ◉ pnpm dev          ⬍ ⬌ ⤢   _  ✕ │
+└──────────────────────────────────────────────────────────────────────────────┘
+ sync  back/fwd/    key      URL              dev-server          split/zoom  min/
+ chip  refresh      badge    (host+path)      connection          (collapse)  kill
+```
+
+- **Sync chip → far left.** The SYNCED/SCALED icon (`FrameCorners`/`Resize`,
+  click → screen modal) sits at the very left edge, out of the way of the nav
+  controls. Behavior unchanged.
+- **Back / forward / refresh** sit where Chrome puts them, immediately left of
+  the URL.
+- **URL is the primary text**, replacing the HTML title. A flexible spacer lives
+  after the URL/connection so the layout buttons stay right-aligned.
+
+Priority order under width pressure: **sync + URL/connection always visible; nav
+buttons collapse next (below ~360px); split/zoom collapse first (below 420px);
+kill always stays.**
+
+### URL over HTML title
+
+The header's primary text is the active tab's **URL (host + path)**; the HTML
+`<title>` is **demoted to the tooltip**. The URL already rides the `tabs` stream.
+The persisted panel title (door labels, session save) stays the tab's display
+title — the URL preference is a live-header concern only, so the multi-tab strip
+still shows HTML titles to tell tabs apart. Both flow body→header through the
+existing screen controller's separate **chrome snapshot** channel (URL / key /
+connection), kept distinct from the screen snapshot so tab/status updates don't
+churn the SYNCED/SCALED chip and vice versa.
+
+### `--key` badge
+
+The `--key` (default `default`) is what `dor ab --key …` targets, so with two or
+more browser surfaces it's exactly what you need to see. A small badge renders
+for **non-default keys only** (`default` is skipped), as a **separate element —
+not a string prefix on the title** — because the title is persisted and we don't
+want `(storybook)` leaking into saved state. It rides the chrome snapshot from
+`params.key`; raw `--session` surfaces (no key) show no badge.
+
+### Dev-server connection
+
+When the active tab URL is **loopback** (`localhost` / `127.0.0.1` / `[::1]` /
+`*.localhost`), Dormouse correlates `<port>` to the **terminal pane serving it**
+and surfaces a clickable chip — e.g. `◉ pnpm dev :5173` — that **focuses that
+terminal** on click (reattaching it first if it's minimized). Dormouse is the
+only tool that owns both the browser surface and the terminals, and the building
+block is `PlatformAdapter.getOpenPorts(id)` (the TCP ports a terminal's process
+tree is listening on).
+
+Mechanics & wrinkles:
+
+- **Where it lives.** A panel can't see other panes' ports, so correlation lives
+  in the **Wall** (`use-dev-server-ports.ts` driving a shared store,
+  `agent-browser-ports.ts`); the header consumes the resolved `{ paneId, label }`
+  and clicks back into the Wall (`onFocusPane`) to focus the pane.
+- **Which binds match.** A pane owns the port when it listens on it with a
+  localhost-reachable bind — loopback (`127.0.0.1` / `::1`) **or** any-interface
+  (`0.0.0.0` / `::`, which still answers `localhost`). A bind on one specific
+  non-loopback interface does not match.
+- **Cost.** `getOpenPorts` has a ~3s timeout, so the correlation runs **only
+  while a loopback port is on screen** — promptly when a header first shows one,
+  then on a slow (~5s) refresh — and at most one sweep is in flight. Visible
+  panes and minimized doors are both scanned (both keep live ptys).
+- **Fallbacks (degrade to just the URL):** non-loopback URL; no pane listening on
+  the port; a bind on a specific non-loopback interface; a tunneled/proxied
+  domain; or two+ panes claiming the port (ambiguous).
+- **Bidirectional (later):** a terminal serving a port could conversely show
+  "viewed in `surface:3`". Out of scope for now; the port store would make it
+  cheap.
+
+### Back / forward / refresh
+
+- **All three are native agent-browser commands** — `back`, `forward`, `reload`
+  — added to the `agentBrowserCommand` allowlist and issued like tab actions, no
+  eval fallback.
+- **No enabled-state.** `canGoBack` / `canGoForward` aren't in the stream, so the
+  buttons are **always enabled** (a click at the ends no-ops) rather than greyed,
+  matching most embedded browsers. They are inert on hosts without
+  `agentBrowserCommand` (Tauri today), like the screen-modal resizes.
+
 ## Screen Indicator & Viewport
 
 The surface viewport is governed by agent-browser's own `set viewport` / `set
@@ -141,8 +235,8 @@ nothing more than a GUI front-end for those native `set` commands.
 
 ### The indicator (SYNCED / SCALED)
 
-Immediately to the **right of the title**, the header shows one of two derived
-states — never a stored mode:
+At the **far left of the header** (see Browser-Chrome Header), the chip shows one
+of two derived states — never a stored mode:
 
 - **`SYNCED`** — the browser's live viewport (CSS pixels) equals the pane's CSS
   pixel size, so the display maps 1:1 with no scaling.
@@ -365,12 +459,14 @@ host on the webview's behalf (a webview cannot spawn processes; see
 | --- | --- |
 | `dor ab` command (passthrough + `--key` intercept) | `dor/src/commands/agent-browser.ts` |
 | Control method `surface.agentBrowser` request/response | `dor/src/commands/types.ts`, `dor/src/control-client.ts` |
-| Surface component (canvas viewer + WS client + tab strip + screenshot loop + sync tracking + SYNCED/SCALED) | `lib/src/components/wall/AgentBrowserPanel.tsx` |
-| SYNCED/SCALED indicator + opens the screen modal (agent-browser surfaces only) | `lib/src/components/wall/SurfacePaneHeader.tsx` |
+| Surface component (canvas viewer + WS client + tab strip + screenshot loop + sync tracking + SYNCED/SCALED + chrome snapshot) | `lib/src/components/wall/AgentBrowserPanel.tsx` |
+| Browser-chrome header (sync chip + back/fwd/reload + URL + key badge + dev-server chip; agent-browser surfaces only) | `lib/src/components/wall/SurfacePaneHeader.tsx` |
 | Screen modal (Sync / Device-registry / Custom; issues native `set …`) | `lib/src/components/wall/AgentBrowserScreenModal.tsx` |
-| Per-surface screen bridge (header↔body↔modal) + modal host | `lib/src/components/wall/agent-browser-screen.ts`, `lib/src/components/AgentBrowserScreenModalHost.tsx` |
+| Per-surface screen+chrome bridge (header↔body↔modal) + modal host | `lib/src/components/wall/agent-browser-screen.ts`, `lib/src/components/AgentBrowserScreenModalHost.tsx` |
+| URL display/loopback-port parsing | `lib/src/components/wall/browser-url.ts` |
+| Dev-server port→pane store (consumed by the header) + Wall-side correlation driver | `lib/src/components/wall/agent-browser-ports.ts`, `lib/src/components/wall/use-dev-server-ports.ts` |
 | Per-surface `syncEngaged` persistence | dockview **panel params**, via the serialized layout blob (no `session-types.ts`/`session-save.ts` change) |
-| Surface registration + control handler + key→session registry | `lib/src/components/Wall.tsx` |
+| Surface registration + control handler + key→session registry + `onFocusPane` | `lib/src/components/Wall.tsx` |
 | Host capabilities + VS Code stream relay | `lib/src/lib/platform/types.ts`, `lib/src/lib/platform/vscode-adapter.ts`, `vscode-ext/src/agent-browser-host.ts`, `vscode-ext/src/message-router.ts` |
 
 ### Host capabilities
@@ -380,9 +476,10 @@ hosts degrade gracefully:
 
 - **`agentBrowserCommand(session, args)`** — runs the user's agent-browser
   binary for tab actions (`tab <n>`, `tab close`, `tab new`), screen-mode
-  resizing (`set viewport`, `set device`), and lifecycle (`close`). The host
-  validates `args[0]` against an allowlist (`tab`, `set`, `screenshot`,
-  `close`); this is not a general exec channel.
+  resizing (`set viewport`, `set device`), history nav (`reload`, `back`,
+  `forward`), and lifecycle (`close`). The host validates `args[0]` against an
+  allowlist (`tab`, `set`, `screenshot`, `reload`, `back`, `forward`, `close`);
+  this is not a general exec channel.
 - **`agentBrowserScreenshot(session, { format, quality })`** — captures one
   device-resolution frame via `agent-browser screenshot` (which honors the
   session DPR, unlike the screencast) and returns the raw bytes (a `Uint8Array`
@@ -514,106 +611,3 @@ baseline on every target.
 - **Re-trigger sync from the CLI** — a Dormouse-reserved `dor ab` verb, at the
   cost of the first non-passthrough subcommand.
 - **Undo/redo chords** — blocked on the upstream stream-input `commands` fix.
-
-## Browser-chrome header (nav + URL + connection)
-
-Today the surface header shows the active tab's **HTML `<title>`** and the
-SYNCED/SCALED icon, and offers no navigation. For a dev workflow the HTML title
-("Vite + React") tells you less than the **URL** — and less still than *where the
-URL comes from*. This proposal reshapes the header to read like a browser and to
-surface the one thing only Dormouse can show: that a localhost page is being
-served by another pane in the same workspace.
-
-### Layout — mirror Chrome's toolbar
-
-Left→right, matching a real browser so it reads as "browser-ish":
-
-```
-┌──────────────────────────────────────────────────────────────────────────────┐
-│ ⤢   ←  →  ⟳    (storybook) localhost:5173   ◉ pnpm dev          ⬍ ⬌ ⤢   _  ✕ │
-└──────────────────────────────────────────────────────────────────────────────┘
- sync  back/fwd/    key      URL              dev-server          split/zoom  min/
- chip  refresh      badge    (host+path)      connection          (collapse)  kill
-```
-
-- **Sync chip → far left.** The SYNCED/SCALED icon (`FrameCorners`/`Resize`,
-  click → screen modal) moves from "right of the title" to the very left edge,
-  out of the way of the new nav controls. Behavior unchanged.
-- **Back / forward / refresh** sit where Chrome puts them, immediately left of
-  the URL.
-- **URL is the primary text**, replacing the HTML title (below). The flexible
-  spacer lives after the URL so the layout buttons stay right-aligned.
-
-All of this is **browser-surface only**, gated on the screen-controller presence
-exactly like today's chip; terminals/iframes are untouched. The header is
-shared (`SurfacePaneHeader.tsx`), and it is already tight and responsive
-(`min-[420px]` collapse). Priority order under width pressure: **sync + URL/
-connection always visible; nav buttons next; split/zoom collapse first** (kill
-stays).
-
-### URL over HTML title
-
-Show the active tab's **URL (host + path)** as the header's primary text;
-**demote the HTML `<title>` to the tooltip**. The URL already rides the `tabs`
-stream (`tabDisplayTitle` even falls back to host+path today) — this just flips
-the preference. The HTML title stays useful in the **multi-tab strip** to tell
-tabs apart, so the change is scoped to the single-surface header.
-
-### `--key` badge
-
-The `--key` (default `default`) is what `dor ab --key … ` targets, so with two
-or more browser surfaces it's exactly what you need to see. Render a small badge
-for **non-default keys only** (skip `default`), as a **separate element — not a
-string prefix on the title** — because the title is persisted (door labels,
-session save) and we don't want `(storybook)` leaking into saved state. It's
-already in `params.key`; raw `--session` surfaces (no key) show nothing (or a
-truncated session) rather than a badge.
-
-### Dev-server connection (the differentiated piece)
-
-When the active tab URL is **loopback** (`localhost` / `127.0.0.1:<port>`),
-correlate `<port>` to the Dormouse **terminal pane serving it** and surface that
-link — e.g. `◉ pnpm dev :5173` — that **jumps to / focuses that terminal** on
-click. Dormouse is the only tool that owns both the browser surface and the
-terminals, and the building block already exists: `PlatformAdapter.getOpenPorts(id)`
-returns the TCP ports a terminal's process tree is listening on. This answers
-"where is this localhost coming from?" and makes the relationship navigable.
-
-Mechanics & wrinkles:
-
-- **Where it lives.** A panel doesn't know other panes' ports, so the
-  port→pane correlation belongs in the **Wall** (or a shared port store the Wall
-  feeds), with the header consuming the resolved `{ paneId, label }`. The header
-  click calls back into the Wall to focus that pane.
-- **The capability exists but is dormant.** `getOpenPorts` is fully plumbed and
-  tested (adapter → message-router → `pty-manager` → per-OS lsof/PowerShell) but
-  currently has **no UI consumer** — so the hard part (per-OS port detection) is
-  done, and this feature is its first consumer; the correlation store + chip are
-  greenfield, nothing to reuse.
-- **Cost.** `getOpenPorts` has a ~3s timeout; polling every pane continuously is
-  wasteful. Compute **on demand only when the active URL is loopback**, on a
-  slow refresh, and cache.
-- **Fallbacks (degrade to just the URL):** non-loopback URL; no pane matches the
-  port; the dev server bound `0.0.0.0`/a specific interface; a tunneled/proxied
-  domain; or (rarely) two panes claiming the port.
-- **Bidirectional (later):** a terminal serving a port could conversely show
-  "viewed in `surface:3`". Out of scope for v1; the port store would make it
-  cheap.
-
-### Back / forward / refresh mechanics
-
-- **All three are native agent-browser commands** — `back`, `forward`, `reload`
-  (verified 0.27.0: `back`/`forward` actually move history). So each is just a
-  new entry on the `agentBrowserCommand` allowlist (`reload`, `back`, `forward`)
-  issued like tab actions — **no eval fallback needed**.
-- **No enabled-state.** `canGoBack`/`canGoForward` are not in the stream, so the
-  buttons are **always enabled** (click no-ops at the ends) rather than greyed —
-  acceptable, matching most embedded browsers. Deriving real enablement would
-  need an extra channel and isn't worth it for v1.
-
-### Touchpoints
-
-`SurfacePaneHeader.tsx` (the browser-only header branch: reorder, nav buttons,
-URL, key badge, connection chip), `Wall.tsx` (new port→pane correlation store +
-focus callback — `getOpenPorts` is already plumbed but unused), and the
-`agentBrowserCommand` allowlist (add `reload`, `back`, `forward`).

--- a/docs/specs/dor-agent-browser.md
+++ b/docs/specs/dor-agent-browser.md
@@ -14,7 +14,7 @@ tabs. We reimplement none of agent-browser's behavior, the same way an HTTP
 client is not a fork of the server.
 
 This is the chosen alternative to the iframe surface (see
-`dor-cli.md` → "Iframe Surface: Limitations And Status"). Because the browser
+[dor-iframe.md](dor-iframe.md)). Because the browser
 renders to a Dormouse-owned `<canvas>` rather than a cross-origin `<iframe>`,
 Dormouse keeps its own keydown listener and never loses focus control: the
 keyboard model that breaks for iframes does not apply here.

--- a/docs/specs/dor-cli.md
+++ b/docs/specs/dor-cli.md
@@ -133,57 +133,6 @@ Invariants:
 - Workspace/window refs and target flags will be added only when Dormouse
   actually supports them.
 
-## Iframe Surface: Limitations And Status
-
-> Status: **provisional.** The `dor iframe` surface works for displaying a page,
-> but has structural limitations (below) that may keep it from shipping. The
-> likely path forward is to ship an **agent-browser** surface instead — a
-> Dormouse-controlled browser view (see `lib/src/components/wall/AgentBrowserPanel.tsx`)
-> that does not embed a foreign page as a peer browsing context — and to drop or
-> hide `dor iframe`. That surface is specified in
-> [dor-agent-browser.md](dor-agent-browser.md). Do not build features on top of
-> the iframe surface until this is resolved.
-
-An `<iframe>` pointed at an arbitrary URL is a **separate browsing context** from
-the Wall. Dormouse's input, focus, and attention model assumes a single
-same-document context, so the iframe surface conflicts with it in ways that are
-inherent to the browser, not bugs we can patch away:
-
-- **Focus leaves Dormouse entirely.** When the iframe gains focus, a focused
-  cross-origin frame owns the keyboard. Its keystrokes fire in *its* document and
-  never reach the parent. Dormouse's global shortcuts are a capturing `window`
-  keydown listener (`lib/src/components/wall/use-wall-keyboard.ts`), so dual-tap-⌘,
-  pane navigation, split, and kill all go dead until focus returns to the Wall.
-  The same-origin policy means the parent cannot observe or intercept those keys —
-  this cannot be fixed, only designed around (e.g. a click-to-interact overlay, or
-  an accept-focus model with a mouse-driven escape affordance).
-
-- **The app reads iframe-focus as being backgrounded.** Focusing the iframe fires
-  a `blur` on the parent `window`. Current handlers treat that as the whole app
-  losing focus: `Wall.tsx` clears cross-session attention, and
-  `use-window-focused.ts` flips `windowFocused` to `false`, which drives the
-  active styling (e.g. `SurfacePaneHeader.tsx`'s `isActiveHeader`). The result is
-  every header/focus-ring goes inactive and attention clears the instant the
-  iframe is focused. This part *is* fixable (distinguish `document.activeElement`
-  being one of our own iframes from a real window blur) but is not yet done.
-
-- **No programmatic focus handle.** `focusSession` (`lib/src/lib/terminal-lifecycle.ts`)
-  only knows xterm terminals in a registry. The iframe pane is not registered, so
-  `onClickPanel → enterTerminalMode → focusSession(iframeId)` is a no-op: Dormouse
-  cannot focus the iframe programmatically and cannot tell when it is focused.
-
-- **Some sites refuse to be framed, with no error signal.** Servers that send
-  `X-Frame-Options` or a CSP `frame-ancestors` directive cannot be embedded at
-  all, yielding a blank pane. Cross-origin frames do not report load errors to the
-  embedder (`onError` never fires; `onLoad` fires even for a blocked frame), so the
-  surface cannot reliably distinguish "loading", "blocked", and "broken". The
-  current `IframePanel` shows a best-effort stall hint after a timeout only.
-
-- **The VS Code webview must opt into framing.** The webview CSP
-  (`vscode-ext/src/webview-html.ts`) is `default-src 'none'`; without a `frame-src`
-  directive every `<iframe>` is blocked outright (blank white pane). A
-  `frame-src http: https:` allowance is required for the surface to render at all.
-
 ## Current Implemented Commands
 
 Implemented commands call private `surface.*` control methods. `surface.list`
@@ -215,7 +164,9 @@ from `command-detail`.
 - `dor send` [impl](../../dor/src/commands/send.ts) [docs](../../dor/test/snapshots/help/send.md)
 - `dor read` [impl](../../dor/src/commands/read.ts) [docs](../../dor/test/snapshots/help/read.md)
 - `dor kill` [impl](../../dor/src/commands/kill.ts) [docs](../../dor/test/snapshots/help/kill.md)
-- `dor iframe` [impl](../../dor/src/commands/iframe.ts) [docs](../../dor/test/snapshots/help/iframe.md)
+- `dor iframe` — **provisional**; high-fidelity URL embed with structural
+  limitations, see [dor-iframe.md](dor-iframe.md).
+  [impl](../../dor/src/commands/iframe.ts) [docs](../../dor/test/snapshots/help/iframe.md)
 - `dor agent-browser` / `dor ab` — delegates to the user's `agent-browser`,
   rendered in a Dormouse-native surface; see [dor-agent-browser.md](dor-agent-browser.md)
   (the chosen alternative to the iframe surface)

--- a/docs/specs/dor-iframe.md
+++ b/docs/specs/dor-iframe.md
@@ -1,0 +1,324 @@
+# Dor Iframe Surface
+
+> See `docs/specs/glossary.md` for canonical Session and Pane vocabulary,
+> `docs/specs/dor-cli.md` for the shared `dor` CLI, surface handle model, and
+> host control plumbing this surface builds on, and
+> `docs/specs/dor-agent-browser.md` for the sibling browser surface.
+
+`dor iframe <url>` opens an absolute `http(s)` URL in a high-fidelity `<iframe>`
+surface for human inspection. Unlike the agent-browser surface (a screencast of a
+real Chromium), the iframe renders the page's **own DOM** directly — zero-lag and
+pixel-perfect — but as a **separate browsing context** that Dormouse neither
+controls nor can observe.
+
+> Status: **provisional.** The surface works for displaying a page, but has
+> structural limitations (below) that keep it from being usable for real
+> interaction today. Two things follow from that: arbitrary web browsing is
+> served by the **agent-browser** surface instead (`dor ab`, see
+> [dor-agent-browser.md](dor-agent-browser.md)), and the iframe's own path
+> forward is the **transparent proxy** in Future Work below, which converts it
+> from a blind embedder into Dormouse-served content and resolves four of the
+> five limitations. Do not build features on top of the raw iframe surface until
+> that lands.
+
+## The Current Surface
+
+`dor iframe <url>` (`dor/src/commands/iframe.ts`) sends a `surface.iframe` control
+request; `parseIframeUrl` constrains inputs to absolute `http://`/`https://`
+(Dormouse does not infer schemes). Placement follows the shared content-surface
+rule (`lib/src/components/Wall.tsx` → `createContentSurface`): an untouched
+terminal caller is replaced in place, anything else gets a split next to the
+caller.
+
+`IframePanel.tsx` renders a bare `<iframe src={url}>`. Because a cross-origin
+frame reports no load result, the panel can only show a **blind 5-second stall
+hint** ("if it stays blank, the server may be down, on a different scheme, or
+refusing to be embedded") — it cannot actually distinguish those cases.
+
+## Structural Limitations
+
+An `<iframe>` pointed at an arbitrary URL is a **separate browsing context** from
+the Wall. Dormouse's input, focus, and attention model assumes a single
+same-document context, so the iframe surface conflicts with it. Some conflicts
+are **inherent to the browser** (only designable-around, never patchable); others
+are **fixable but not yet done**.
+
+### Inherent
+
+- **Focus leaves Dormouse entirely.** When the iframe gains focus, a focused
+  cross-origin frame owns the keyboard. Its keystrokes fire in *its* document and
+  never reach the parent. Dormouse's global shortcuts are a capturing `window`
+  keydown listener (`lib/src/components/wall/use-wall-keyboard.ts`), so
+  dual-tap-⌘, pane navigation, split, and kill all go dead until focus returns to
+  the Wall. The same-origin policy means the parent cannot observe or intercept
+  those keys — this cannot be fixed, only designed around (a click-to-interact
+  overlay, or an accept-focus model with a mouse-driven escape).
+
+- **Some sites refuse to be framed, with no error signal.** Servers that send
+  `X-Frame-Options` or a CSP `frame-ancestors` directive cannot be embedded at
+  all, yielding a blank pane. Cross-origin frames do not report load errors to the
+  embedder (`onError` never fires; `onLoad` fires even for a blocked frame), so
+  the surface cannot reliably distinguish "loading", "blocked", and "broken". The
+  current `IframePanel` shows a best-effort stall hint after a timeout only.
+
+### Fixable but not yet done
+
+- **The app reads iframe-focus as being backgrounded.** Focusing the iframe fires
+  a `blur` on the parent `window`. Current handlers treat that as the whole app
+  losing focus: `Wall.tsx` clears cross-session attention, and
+  `use-window-focused.ts` flips `windowFocused` to `false` (it is naïve —
+  `onBlur = () => setFocused(false)`), which drives active styling (e.g.
+  `SurfacePaneHeader.tsx`'s `isActiveHeader`). The result is every
+  header/focus-ring goes inactive and attention clears the instant the iframe is
+  focused. The fix is to distinguish `document.activeElement` being one of our own
+  iframes from a real window blur.
+
+- **No programmatic focus handle.** `focusSession`
+  (`lib/src/lib/terminal-lifecycle.ts`) only knows xterm terminals in a registry.
+  The iframe pane is not registered, so
+  `onClickPanel → enterTerminalMode → focusSession(iframeId)` is a no-op: Dormouse
+  cannot focus the iframe programmatically and cannot tell when it is focused.
+
+### Host config
+
+- **The VS Code webview must opt into framing.** The webview CSP
+  (`vscode-ext/src/webview-html.ts`) is `default-src 'none'`; without a `frame-src`
+  directive every `<iframe>` is blocked outright (blank white pane). Today a broad
+  `frame-src http: https:` allowance is required for the surface to render at all
+  (narrowed by the proxy below).
+
+---
+
+# Future Work
+
+> Designed, not yet built. Everything above describes the surface as it exists
+> today; everything below is the roadmap.
+
+The through-line: an `<iframe>` is only crippled when it points at a foreign
+context. Put a **host-owned transparent proxy** in front of it and Dormouse
+becomes the server — it controls the bytes, which is the one thing the raw iframe
+lacks. From there the surface gains a keyboard side-channel, an accurate focus
+model, and real error signals; and it becomes one render backend in a small
+family shared with agent-browser.
+
+## The Transparent Proxy (Instrumented Iframe)
+
+This is the **substrate** under everything else here. Instead of pointing the
+`<iframe>` at the target, Dormouse points it at a loopback proxy that fetches the
+target and serves it back. The moment Dormouse serves the bytes, two things become
+possible that the raw iframe cannot do — and together they resolve limitations
+#1–#4 above:
+
+1. **Inject a keyboard side-channel** so Dormouse's global chords keep working
+   inside the frame (the technique VS Code uses for its own webviews).
+2. **See the upstream result**, so a refused-to-be-framed page or a dead server
+   becomes a clear error instead of a blank pane.
+
+### The one load-bearing fact
+
+Same-origin policy blocks the **parent from reaching into the child**
+(`iframe.contentDocument` throws cross-origin). It does **not** block the **child
+from posting to the parent** — `window.parent.postMessage()` is cross-origin-safe
+by design. Dormouse can never reach *in*, but a script *we put in the served HTML*
+can always call out. The only capability we need is control over the served
+bytes, which the proxy gives us. This is exactly how VS Code instruments its
+plugin webviews — serve HTML from an origin you own, inject a bootstrap that
+forwards keydowns — not a new technique, the proven one.
+
+### Target policy: loopback instruments, remote diagnoses
+
+The policy hinges on **loopback vs remote**, because only loopback targets are
+"the user's own tools" where forcing framing and stripping headers is safe and
+intended.
+
+| Target | Frame-blocking headers | Proxy behavior |
+| --- | --- | --- |
+| **Loopback** (`localhost`/`127.0.0.1`/`[::1]`) | stripped | Full instrument: relax CSP, drop `X-Frame-Options`/`frame-ancestors`, inject shim, serve. The user spawned it; framing is the intent. |
+| **Remote**, frameable | honored | Best-effort render with the leader shim, flagged that `dor ab` is the better tool. *(Open decision — may degrade to error-only.)* |
+| **Remote**, refuses framing | honored | **Do not strip.** Serve a Dormouse error page explaining why, with a one-click hint to `dor ab open <url>`. |
+| **Unreachable** (conn refused, DNS, non-2xx) | — | Serve a Dormouse error page ("is the dev server running?"). |
+
+We do **not** force-frame third-party sites: rewriting authenticated
+cross-origin pages through a proxy is an auth/cookie/ToS dead end, and that's
+what the agent-browser surface is for. v1 proxies `http://` upstreams (loopback
+dev servers are overwhelmingly plain http) plus WebSocket upgrades; `https://`
+upstreams are deferred.
+
+### The keyboard side-channel (resolves #1)
+
+A fixed, Dormouse-owned script — like agent-browser's `EDIT_SCRIPTS`, never
+user-supplied, so it is not an eval vector — injected before `</head>`:
+
+```js
+// Reclaim ONLY Dormouse's reserved leader chord; everything else flows to the
+// tool untouched. The tool keeps full keyboard interactivity; Dormouse keeps
+// its global shortcuts.
+addEventListener('keydown', (e) => {
+  if (isDormouseLeader(e)) {
+    parent.postMessage({ __dormouse: 'leader-keydown', key: e.key, code: e.code,
+      ctrlKey: e.ctrlKey, metaKey: e.metaKey, altKey: e.altKey, shiftKey: e.shiftKey }, '*');
+  }
+}, true);
+addEventListener('focus', () => parent.postMessage({ __dormouse: 'focus' }, '*'), true);
+addEventListener('blur',  () => parent.postMessage({ __dormouse: 'blur'  }, '*'), true);
+```
+
+The forwarding is **asymmetric and minimal**: the embedded tool (a code editor, a
+full VS-Code-web workbench) wants nearly every keystroke and has its own
+keybindings; Dormouse only needs to reclaim its handful of global chords. The Wall
+already owns a capturing `window` keydown listener
+(`use-wall-keyboard.ts`); it gains a `message` listener that validates the origin
+against the live proxy grant, then feeds the forwarded chord into the same
+keybinding dispatch — preferably by calling the dispatcher with the serialized
+payload directly, not by re-dispatching a synthesized `KeyboardEvent` (whose
+constructor drops `keyCode`/`which`; VS Code works around it with
+`Object.defineProperty`, a wrinkle we skip by not round-tripping a DOM event).
+
+### Accurate focus model (resolves #2 and #3)
+
+The shim's `focus`/`blur` messages let the Wall keep an accurate model:
+
+- **#2** — the Wall distinguishes "one of our own instrumented panes took focus"
+  from a real window blur and keeps `windowFocused` true.
+- **#3** — the surface registers a focus handle that posts a `focus-yourself`
+  message to the shim, so `onClickPanel → enterTerminalMode` can focus the pane
+  like any other surface.
+
+### Real error signals (resolves #4)
+
+With the proxy, **Dormouse is the server**, so it sees the upstream result and
+renders a precise error *page* (served from the proxy origin, which the iframe
+loads normally): refused framing → "`google.com` refuses to be embedded
+(`X-Frame-Options: DENY`); open it with `dor ab open https://google.com`"; server
+down → "nothing responding at `localhost:8080` — is the dev server running?".
+This turns the `google.com`-into-an-iframe dead end into an actionable message.
+
+### Proxy mechanism
+
+Modeled on the agent-browser **stream relay**
+(`vscode-ext/src/agent-browser-host.ts`) — already a loopback-only, tokenized,
+single-purpose forwarder. Differences: this proxy speaks **HTTP** (parses and
+rewrites responses) rather than being a dumb byte pipe, and passes through
+**WebSocket upgrades** (dev-server HMR, openvscode-server's connection).
+
+- **Loopback bind, per-surface token grant** (TTL + lazy sweep), exactly like
+  `createStreamRelayUrl`. The proxy forwards only to the exact granted upstream
+  for a valid token — never a general-purpose open proxy.
+- **Single origin, path-preserving.** Each grant maps a proxy URL
+  (`http://127.0.0.1:<proxyPort>/<token>/…`) to one fixed upstream; root-relative
+  URLs resolve against the proxy origin and get proxied transparently.
+- **Response rewriting.** For `text/html` from a loopback upstream: strip
+  `X-Frame-Options`, neutralize CSP `frame-ancestors`, replace the page CSP with
+  one permitting the tool plus the injected shim's nonce, inject the shim.
+  Non-HTML passes through.
+- **Anti-framebust.** The `<iframe>` uses a `sandbox` without
+  `allow-top-navigation`, so a tool's `if (top !== self) top.location = …` cannot
+  navigate the Wall away.
+
+### Host capability and CSP
+
+A new optional `PlatformAdapter` method mirroring `getAgentBrowserStreamUrl`
+(`lib/src/lib/platform/types.ts`), so hosts degrade gracefully:
+
+```ts
+createIframeProxyUrl?(targetUrl: string): Promise<
+  | { ok: true; url: string }
+  | { ok: false; reason: 'frame-refused' | 'unreachable' | 'scheme'; detail?: string }
+>;
+```
+
+VS Code implements it in the extension host alongside the stream relay (a sibling
+`iframe-proxy-host.ts`). **The proxy is needed on every host** — even where a
+Tauri webview could frame `http://127.0.0.1` directly for origin reasons,
+injection still requires controlling the bytes — unlike the agent-browser relay,
+which was a VS-Code-only origin fix. With the proxy, the VS Code webview CSP
+(`vscode-ext/src/webview-html.ts`) narrows from the broad `frame-src http:
+https:` to the loopback proxy origin only:
+
+```
+frame-src http://127.0.0.1:* http://localhost:*
+```
+
+### Security model
+
+The same fences as the stream relay: loopback-only bind both sides; per-surface
+token grants (no open forwarder); **header-stripping restricted to loopback**
+(remote upstreams never stripped — no force-framing third-party sites); the
+injected shim is fixed and Dormouse-owned (no user script ever reaches the page).
+**SSRF consideration:** the proxy fetches a user-supplied URL (an SSRF shape, e.g.
+cloud metadata `169.254.169.254`); the trust boundary is the user's own
+`dor iframe <url>` so risk is bounded, but the proxy should consider refusing
+link-local/metadata ranges.
+
+## Render Backends: Two Axes
+
+With the proxy in place, "view a web thing in a pane" factors into two
+**independent axes**, and the agent-browser and iframe surfaces are just cells in
+the grid:
+
+| | **Target: just a URL** | **Target: a backend Dormouse spawns & owns** |
+| --- | --- | --- |
+| **Render: screencast** (agent-browser) | `dor ab open <url>` — today | (possible, rarely wanted) |
+| **Render: embed** (proxy + shim iframe) | `dor iframe <localhost>` — above | **the plugin system (Path 2)** |
+
+- **Render axis** = *how* you see it. `screencast` (real Chromium, agent-drivable,
+  any URL, laggy) vs `embed` (the page's own DOM, zero-lag, loopback-only, not
+  agent-drivable).
+- **Target axis** = *what* you point at. A bare URL, vs. a URL whose backend
+  process Dormouse spawns and reaps.
+
+The shim and proxy live **entirely in the `embed` render backend**, which is why
+both paths below reuse them unchanged — they differ only in which other axis they
+exercise.
+
+## Path 1 — Swappable Render Backend
+
+Expose the **render axis** as a per-pane choice: same target, switch screencast ↔
+embed. This is the hedge on the agent-browser bet — if the screencast's lag is
+unacceptable for a local dev server, one gesture swaps it to the zero-lag embed.
+
+**Do not fuse the surfaces into a dual-mode mega-component.** `AgentBrowserPanel`
+is already 840 lines and the input models differ fundamentally (CDP `input_*`
+messages vs native DOM). Instead, make the swap a **layout operation: replace the
+pane's renderer in place, preserving the target.** `createContentSurface` already
+replaces an untouched terminal in its slot — generalize that to "replace surface X
+with surface Y at the same dock position," triggered by a header affordance ("open
+in iframe" / "open in browser"). The substrate makes this nearly free.
+
+## Path 2 — Plugin System
+
+Extend the **target axis** with process ownership: Dormouse spawns the plugin's
+backend (an HTML editor, `openvscode-server` / `code serve-web`, any local tool)
+and renders it through the same `embed` backend. The rendering is solved by the
+proxy; what Path 2 adds is a **process supervisor** — spawn (in what cwd/env?
+per-workspace or per-pane? reuse across panes?), allocate/health-check the port,
+wire the proxy to it, and **reap the process when the pane is killed.**
+
+That last requirement is the second consumer that justifies generalizing the
+per-surface **teardown-on-kill hook** — the one-off `agent-browser` close
+currently special-cased in `Wall.tsx`'s `killPaneImmediately` (see
+[dor-agent-browser.md](dor-agent-browser.md) → Lifecycle). A plugin backend that
+leaks when its pane closes is a real bug, so the abstraction stops being premature
+exactly here.
+
+**Risk specific to the motivating example (code-server / openvscode-server):**
+it will stress the substrate more than a Vite dev server — worth a spike before
+committing. It needs `allow-same-origin allow-scripts allow-forms allow-popups
+allow-downloads allow-modals` (still omitting `allow-top-navigation` for the
+anti-framebust guarantee); may want COOP/COEP for cross-origin isolation
+(SharedArrayBuffer) — verify against the actual target; and leans on WebSocket
+passthrough harder than most.
+
+## Open Decisions
+
+1. **Remote frameable targets** — render best-effort with the leader shim, or
+   always route remote to an error page that points at `dor ab`? The latter keeps
+   a crisp "loopback = iframe, remote = agent-browser" line.
+2. **Absolute-origin sub-resources.** Dev servers emitting absolute
+   `http://localhost:5173/...` URLs bypass the proxy origin — widen CSP to allow
+   the loopback upstream (cheap) vs. rewrite response bodies (invasive)?
+3. **SSRF range-blocking** — refuse link-local/metadata/private ranges, or trust
+   the user's own command?
+4. **Web host** — no host process to run a proxy: hide the surface, or keep the
+   blind raw-iframe fallback?
+</content>

--- a/lib/.storybook/main.ts
+++ b/lib/.storybook/main.ts
@@ -19,6 +19,12 @@ const config: StorybookConfig = {
       '@tauri-apps/plugin-shell': stub,
       '@tauri-apps/plugin-updater': stub,
       'dormouse-lib': path.resolve(here, '..', 'src'),
+      // Mirror tsconfig.app.json's `dor/* → ../dor/src/*` mapping so stories
+      // that import `Wall` (which pulls `dor/commands/*`, `dor/protocol`)
+      // resolve. Storybook's Vite doesn't read tsconfig paths, so without this
+      // any Wall-importing story fails with "Failed to resolve import 'dor/…'".
+      // Safe next to `dormouse-lib`: a string alias only matches `dor` or `dor/…`.
+      dor: path.resolve(here, '..', '..', 'dor', 'src'),
     };
     return config;
   },

--- a/lib/package.json
+++ b/lib/package.json
@@ -10,7 +10,7 @@
     "preview": "vite preview",
     "test": "vitest run",
     "test:watch": "vitest",
-    "storybook": "storybook dev -p 6006",
+    "storybook": "storybook dev -p 6006 --no-open",
     "build-storybook": "storybook build"
   },
   "dependencies": {

--- a/lib/src/components/Baseboard.tsx
+++ b/lib/src/components/Baseboard.tsx
@@ -7,14 +7,12 @@ import { IS_MAC } from '../lib/platform';
 import {
   buildAppTitleResolver,
   DEFAULT_ACTIVITY_STATE,
-  deriveHeader,
   getActivitySnapshot,
   getTerminalPaneStateSnapshot,
-  resolveDisplayPrimary,
   subscribeToActivity,
   subscribeToTerminalPaneState,
 } from '../lib/terminal-registry';
-import { createTerminalPaneState, type TerminalPaneState } from '../lib/terminal-state';
+import { createTerminalPaneState, deriveSurfaceLabel, type TerminalPaneState } from '../lib/terminal-state';
 
 export interface BaseboardProps {
   items: DooredItem[];
@@ -227,5 +225,5 @@ function deriveDoorTitle(
 ): string {
   const paneState = terminalStates.get(id) ?? createTerminalPaneState();
   const visible = allPaneStates.length > 0 ? allPaneStates : [paneState];
-  return resolveDisplayPrimary(deriveHeader(paneState, visible, { appTitleForPane }).primary, savedTitle);
+  return deriveSurfaceLabel(paneState, visible, appTitleForPane, savedTitle);
 }

--- a/lib/src/components/MobileTerminalUi.tsx
+++ b/lib/src/components/MobileTerminalUi.tsx
@@ -39,6 +39,7 @@ import {
   type MobileGestureTrackingState,
 } from '../lib/mobile-gesture-menu';
 import { useDynamicPalette } from '../lib/themes/use-dynamic-palette';
+import { isEditableTarget } from '../lib/dom';
 import { TouchUiContext } from './touch-ui-context';
 import type { SessionStatus } from '../lib/terminal-registry';
 
@@ -508,13 +509,7 @@ export function MobileTerminalUi({
       const active = document.activeElement;
       if (!(active instanceof HTMLElement)) return;
       if (!terminalHostRef.current?.contains(active)) return;
-      if (
-        active instanceof HTMLInputElement
-        || active instanceof HTMLTextAreaElement
-        || active.isContentEditable
-      ) {
-        active.blur();
-      }
+      if (isEditableTarget(active)) active.blur();
     };
     // Wall defers xterm focus via rAF, so a single blur can be reverted after we
     // return; repeat across rAF and a few staggered ticks. See mobile-ui.md §10.

--- a/lib/src/components/Wall.tsx
+++ b/lib/src/components/Wall.tsx
@@ -62,6 +62,7 @@ import { useDockviewReady } from './wall/use-dockview-ready';
 import { pickSplitDirection } from './wall/dockview-helpers';
 import { useWallKeyboard } from './wall/use-wall-keyboard';
 import { useSessionPersistence } from './wall/use-session-persistence';
+import { useDevServerPortCorrelation } from './wall/use-dev-server-ports';
 import { useWindowFocused } from './wall/use-window-focused';
 import {
   DialogKeyboardContext,
@@ -640,6 +641,9 @@ export function Wall({
     selectedIdRef,
     selectedTypeRef,
   });
+
+  // --- Dev-server port → pane correlation (browser header connection chip) ---
+  useDevServerPortCorrelation({ apiRef, doorsRef });
 
   // --- Reattach ---
 
@@ -1470,6 +1474,16 @@ export function Wall({
     onClickPanel: (id: string) => {
       setConfirmKill(null);
       enterTerminalMode(id);
+    },
+    onFocusPane: (id: string) => {
+      setConfirmKill(null);
+      // Visible pane → jump straight in; minimized (a door) → reattach first.
+      if (apiRef.current?.getPanel(id)) {
+        enterTerminalMode(id);
+        return;
+      }
+      const door = doorsRef.current.find((item) => item.id === id);
+      if (door) handleReattachRef.current(door, { enterPassthrough: true });
     },
     onStartRename: (id: string) => {
       setRenamingPaneId(id);

--- a/lib/src/components/Wall.tsx
+++ b/lib/src/components/Wall.tsx
@@ -33,8 +33,7 @@ import {
 import {
   buildAppTitleResolver,
   createTerminalPaneState,
-  deriveHeader,
-  resolveDisplayPrimary,
+  deriveSurfaceLabel,
   surfaceRunsCommand,
 } from '../lib/terminal-state';
 import { orchestrateKill } from '../lib/kill-animation';
@@ -56,6 +55,7 @@ import { TerminalPanel } from './wall/TerminalPanel';
 import { TerminalPaneHeader } from './wall/TerminalPaneHeader';
 import { AgentBrowserPanel } from './wall/AgentBrowserPanel';
 import { IframePanel } from './wall/IframePanel';
+import { hostPathDisplay } from './wall/browser-url';
 import { SurfacePaneHeader } from './wall/SurfacePaneHeader';
 import { WorkspaceSelectionOverlay } from './wall/WorkspaceSelectionOverlay';
 import { useDockviewReady } from './wall/use-dockview-ready';
@@ -170,16 +170,6 @@ function surfaceTypeFromParams(params: unknown): DorSurfaceType {
     if (surfaceType === 'iframe' || surfaceType === 'agent-browser') return surfaceType;
   }
   return 'terminal';
-}
-
-function iframeTitle(url: string): string {
-  try {
-    const parsed = new URL(url);
-    const path = parsed.pathname === '/' ? '' : parsed.pathname;
-    return `${parsed.host}${path}${parsed.search}`;
-  } catch {
-    return url;
-  }
 }
 
 function componentForSurfaceType(type: DorSurfaceType): string {
@@ -766,9 +756,8 @@ export function Wall({
     return panels.map((panel, index) => {
       const type = surfaceTypeFromParams(panel.params);
       const state = panelStates[index] ?? createTerminalPaneState();
-      const derived = deriveHeader(state, panelStates, { appTitleForPane });
       const title = type === 'terminal'
-        ? resolveDisplayPrimary(derived.primary, panel.title ?? panel.id)
+        ? deriveSurfaceLabel(state, panelStates, appTitleForPane, panel.title ?? panel.id)
         : (panel.title ?? panel.id);
 
       return {
@@ -1300,7 +1289,7 @@ export function Wall({
           minimized: booleanParam(params.minimized),
           params: { surfaceType: 'iframe', url },
           reference: target.value,
-          title: iframeTitle(url),
+          title: hostPathDisplay(url, true),
         });
         if (!result.ok) {
           detail.respond({ ok: false, error: result.message });

--- a/lib/src/components/wall/AgentBrowserPanel.tsx
+++ b/lib/src/components/wall/AgentBrowserPanel.tsx
@@ -12,6 +12,7 @@ import { clsx } from 'clsx';
 import { TERMINAL_BOTTOM_RADIUS_CLASS } from '../design';
 import { getPlatform } from '../../lib/platform';
 import { readTextFromClipboard } from '../../lib/clipboard';
+import { isEditableTarget } from '../../lib/dom';
 import {
   openAgentBrowserScreenModal,
   registerAgentBrowserScreen,
@@ -764,8 +765,7 @@ export function AgentBrowserPanel({ api, params }: IDockviewPanelProps<AgentBrow
       if (e.target instanceof Element && e.target.closest('[role="dialog"]')) return;
       // Likewise never hijack keystrokes destined for an editable field that
       // lives outside the pane — notably the header's URL editor.
-      if (e.target instanceof HTMLElement &&
-        (e.target.isContentEditable || e.target.tagName === 'INPUT' || e.target.tagName === 'TEXTAREA' || e.target.tagName === 'SELECT')) return;
+      if (isEditableTarget(e.target)) return;
       e.preventDefault();
       if (e.type === 'keydown') handleKeyDownLike(e);
       else sendKey(e, 'keyUp');

--- a/lib/src/components/wall/AgentBrowserPanel.tsx
+++ b/lib/src/components/wall/AgentBrowserPanel.tsx
@@ -16,7 +16,6 @@ import {
   openAgentBrowserScreenModal,
   registerAgentBrowserScreen,
   type ChromeActions,
-  type ChromeConnection,
   type ChromeSnapshot,
   type ScreenActions,
   type ScreenRegistration,
@@ -395,7 +394,7 @@ export function AgentBrowserPanel({ api, params }: IDockviewPanelProps<AgentBrow
     };
   }, [wsPort, runAgentBrowser, maybeDisengageSync, publishScreen, screenshotLoop, drawBitmap]);
 
-  // --- header: persisted title + browser-chrome (URL / key / connection) ---
+  // --- header: persisted title + browser-chrome (URL / key) ---
 
   const activeTab = useMemo(() => tabs.find((tab) => tab.active) ?? tabs[0] ?? null, [tabs]);
 
@@ -409,18 +408,11 @@ export function AgentBrowserPanel({ api, params }: IDockviewPanelProps<AgentBrow
   // The browser-chrome snapshot the header reads. Recomputed each render and
   // mirrored into a ref so a (re-)registration always seeds the latest; the
   // publish effect below pushes it to subscribers only on real changes.
-  const chromeConnection: ChromeConnection =
-    connectionLost || status?.connected === false
-      ? 'lost'
-      : status?.connected === true
-        ? 'connected'
-        : 'connecting';
   const chromeSnapshot: ChromeSnapshot = {
     url: activeTab?.url ?? '',
     displayUrl: activeTab ? hostPathDisplay(activeTab.url) : '',
     title: activeTab?.title ?? null,
     key: params?.key ?? null,
-    connection: chromeConnection,
   };
   const chromeSnapshotRef = useRef(chromeSnapshot);
   chromeSnapshotRef.current = chromeSnapshot;
@@ -485,7 +477,7 @@ export function AgentBrowserPanel({ api, params }: IDockviewPanelProps<AgentBrow
   // tab/status changes, not every frame pulse.
   useEffect(() => {
     registrationRef.current?.updateChrome(chromeSnapshotRef.current);
-  }, [chromeSnapshot.url, chromeSnapshot.displayUrl, chromeSnapshot.title, chromeSnapshot.key, chromeSnapshot.connection]);
+  }, [chromeSnapshot.url, chromeSnapshot.displayUrl, chromeSnapshot.title, chromeSnapshot.key]);
 
   // Persist sync state into the panel params so it round-trips through the
   // dockview layout blob (and survives reattach). Skip no-op writes.

--- a/lib/src/components/wall/AgentBrowserPanel.tsx
+++ b/lib/src/components/wall/AgentBrowserPanel.tsx
@@ -421,6 +421,7 @@ export function AgentBrowserPanel({ api, params }: IDockviewPanelProps<AgentBrow
   // (allowlisted in agentBrowserCommand). Stable; reads the live closure via
   // the ref so the registered controller never goes stale.
   const chromeActions = useMemo<ChromeActions>(() => ({
+    navigate(url) { if (url) runAgentBrowserRef.current(['open', url]); },
     back() { runAgentBrowserRef.current(['back']); },
     forward() { runAgentBrowserRef.current(['forward']); },
     reload() { runAgentBrowserRef.current(['reload']); },
@@ -760,6 +761,10 @@ export function AgentBrowserPanel({ api, params }: IDockviewPanelProps<AgentBrow
       // contains() check above misses it; without this, typing into the modal's
       // Custom W/H/DPI fields would be swallowed and forwarded to the browser.
       if (e.target instanceof Element && e.target.closest('[role="dialog"]')) return;
+      // Likewise never hijack keystrokes destined for an editable field that
+      // lives outside the pane — notably the header's URL editor.
+      if (e.target instanceof HTMLElement &&
+        (e.target.isContentEditable || e.target.tagName === 'INPUT' || e.target.tagName === 'TEXTAREA' || e.target.tagName === 'SELECT')) return;
       e.preventDefault();
       if (e.type === 'keydown') handleKeyDownLike(e);
       else sendKey(e, 'keyUp');

--- a/lib/src/components/wall/AgentBrowserPanel.tsx
+++ b/lib/src/components/wall/AgentBrowserPanel.tsx
@@ -15,11 +15,15 @@ import { readTextFromClipboard } from '../../lib/clipboard';
 import {
   openAgentBrowserScreenModal,
   registerAgentBrowserScreen,
+  type ChromeActions,
+  type ChromeConnection,
+  type ChromeSnapshot,
   type ScreenActions,
   type ScreenRegistration,
   type ScreenSnapshot,
   type ScreenState,
 } from './agent-browser-screen';
+import { hostPathDisplay } from './browser-url';
 import {
   EDIT_OPS,
   MOUSE_BUTTONS,
@@ -84,13 +88,7 @@ type StreamStatus = {
 function tabDisplayTitle(tab: StreamTab): string {
   const title = tab.title?.trim();
   if (title) return title;
-  try {
-    const parsed = new URL(tab.url);
-    const path = parsed.pathname === '/' ? '' : parsed.pathname;
-    return `${parsed.host}${path}` || tab.url;
-  } catch {
-    return tab.url || 'untitled';
-  }
+  return hostPathDisplay(tab.url) || 'untitled';
 }
 
 // Decode a base64 screencast frame to an ImageBitmap (the fallback display path
@@ -397,12 +395,44 @@ export function AgentBrowserPanel({ api, params }: IDockviewPanelProps<AgentBrow
     };
   }, [wsPort, runAgentBrowser, maybeDisengageSync, publishScreen, screenshotLoop, drawBitmap]);
 
-  // --- header title follows the active tab ---
+  // --- header: persisted title + browser-chrome (URL / key / connection) ---
 
+  const activeTab = useMemo(() => tabs.find((tab) => tab.active) ?? tabs[0] ?? null, [tabs]);
+
+  // The persisted panel title (door labels, session save) stays the active
+  // tab's display title; the live browser-chrome header shows the URL instead
+  // (from the snapshot below) and demotes this title to a tooltip.
   useEffect(() => {
-    const active = tabs.find((tab) => tab.active) ?? tabs[0];
-    if (active) api.setTitle(tabDisplayTitle(active));
-  }, [tabs, api]);
+    if (activeTab) api.setTitle(tabDisplayTitle(activeTab));
+  }, [activeTab, api]);
+
+  // The browser-chrome snapshot the header reads. Recomputed each render and
+  // mirrored into a ref so a (re-)registration always seeds the latest; the
+  // publish effect below pushes it to subscribers only on real changes.
+  const chromeConnection: ChromeConnection =
+    connectionLost || status?.connected === false
+      ? 'lost'
+      : status?.connected === true
+        ? 'connected'
+        : 'connecting';
+  const chromeSnapshot: ChromeSnapshot = {
+    url: activeTab?.url ?? '',
+    displayUrl: activeTab ? hostPathDisplay(activeTab.url) : '',
+    title: activeTab?.title ?? null,
+    key: params?.key ?? null,
+    connection: chromeConnection,
+  };
+  const chromeSnapshotRef = useRef(chromeSnapshot);
+  chromeSnapshotRef.current = chromeSnapshot;
+
+  // Native history nav — `back`/`forward`/`reload` issued like tab actions
+  // (allowlisted in agentBrowserCommand). Stable; reads the live closure via
+  // the ref so the registered controller never goes stale.
+  const chromeActions = useMemo<ChromeActions>(() => ({
+    back() { runAgentBrowserRef.current(['back']); },
+    forward() { runAgentBrowserRef.current(['forward']); },
+    reload() { runAgentBrowserRef.current(['reload']); },
+  }), []);
 
   // --- screen controller: register for the header/modal bridge ---
 
@@ -437,6 +467,8 @@ export function AgentBrowserPanel({ api, params }: IDockviewPanelProps<AgentBrow
     const registration = registerAgentBrowserScreen(api.id, {
       snapshot: computeSnapshot(),
       actions: screenActions,
+      chrome: chromeSnapshotRef.current,
+      chromeActions,
       hostCapable: !!getPlatform().agentBrowserCommand,
     });
     registrationRef.current = registration;
@@ -446,7 +478,14 @@ export function AgentBrowserPanel({ api, params }: IDockviewPanelProps<AgentBrow
       registration.dispose();
       registrationRef.current = null;
     };
-  }, [api.id, screenActions, computeSnapshot, publishScreen]);
+  }, [api.id, screenActions, chromeActions, computeSnapshot, publishScreen]);
+
+  // Push browser-chrome changes to the header on a channel separate from the
+  // screen snapshot. Gated on the primitive fields so it fires on real
+  // tab/status changes, not every frame pulse.
+  useEffect(() => {
+    registrationRef.current?.updateChrome(chromeSnapshotRef.current);
+  }, [chromeSnapshot.url, chromeSnapshot.displayUrl, chromeSnapshot.title, chromeSnapshot.key, chromeSnapshot.connection]);
 
   // Persist sync state into the panel params so it round-trips through the
   // dockview layout blob (and survives reattach). Skip no-op writes.

--- a/lib/src/components/wall/AgentBrowserPanel.tsx
+++ b/lib/src/components/wall/AgentBrowserPanel.tsx
@@ -478,7 +478,8 @@ export function AgentBrowserPanel({ api, params }: IDockviewPanelProps<AgentBrow
   // tab/status changes, not every frame pulse.
   useEffect(() => {
     registrationRef.current?.updateChrome(chromeSnapshotRef.current);
-  }, [chromeSnapshot.url, chromeSnapshot.displayUrl, chromeSnapshot.title, chromeSnapshot.key]);
+    // displayUrl is a pure function of url, so url covers it.
+  }, [chromeSnapshot.url, chromeSnapshot.title, chromeSnapshot.key]);
 
   // Persist sync state into the panel params so it round-trips through the
   // dockview layout blob (and survives reattach). Skip no-op writes.

--- a/lib/src/components/wall/SurfacePaneHeader.test.tsx
+++ b/lib/src/components/wall/SurfacePaneHeader.test.tsx
@@ -1,0 +1,151 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { IDockviewPanelHeaderProps } from 'dockview-react';
+import { SurfacePaneHeader } from './SurfacePaneHeader';
+import {
+  registerAgentBrowserScreen,
+  type ChromeSnapshot,
+  type ScreenSnapshot,
+} from './agent-browser-screen';
+import { setDevServerResolution } from './agent-browser-ports';
+import { WallActionsContext, type WallActions } from './wall-context';
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+const SCREEN: ScreenSnapshot = {
+  state: 'SYNCED',
+  viewport: { w: 1280, h: 720, dpr: 1 },
+  paneCss: { w: 1280, h: 720 },
+  displayDpr: 1,
+  syncEngaged: true,
+};
+
+const CHROME: ChromeSnapshot = {
+  url: 'http://localhost:5173/app',
+  displayUrl: 'localhost:5173/app',
+  title: 'Vite + React',
+  key: 'storybook',
+  connection: 'connected',
+};
+
+function stubActions(overrides: Partial<WallActions> = {}): WallActions {
+  return {
+    onKill: vi.fn(),
+    onMinimize: vi.fn(),
+    onAlertButton: vi.fn(() => 'noop'),
+    onToggleTodo: vi.fn(),
+    onSplitH: vi.fn(),
+    onSplitV: vi.fn(),
+    onZoom: vi.fn(),
+    onClickPanel: vi.fn(),
+    onFocusPane: vi.fn(),
+    onStartRename: vi.fn(),
+    onFinishRename: vi.fn(() => ({ accepted: true })),
+    onCancelRename: vi.fn(),
+    ...overrides,
+  };
+}
+
+function register(id: string, chrome: ChromeSnapshot = CHROME) {
+  return registerAgentBrowserScreen(id, {
+    snapshot: SCREEN,
+    actions: { engageSync: vi.fn(), applyDevice: vi.fn(), applyViewport: vi.fn(), openModal: vi.fn() },
+    chrome,
+    chromeActions: { back: vi.fn(), forward: vi.fn(), reload: vi.fn() },
+    hostCapable: true,
+  });
+}
+
+function headerApi(id: string, title: string): IDockviewPanelHeaderProps {
+  return { api: { id, title } } as unknown as IDockviewPanelHeaderProps;
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+function renderHeader(props: IDockviewPanelHeaderProps, actions: WallActions) {
+  act(() => {
+    root.render(
+      <WallActionsContext.Provider value={actions}>
+        <SurfacePaneHeader {...props} />
+      </WallActionsContext.Provider>,
+    );
+  });
+}
+
+describe('SurfacePaneHeader — browser chrome', () => {
+  it('shows the URL as primary text with the HTML title as a tooltip', () => {
+    const registration = register('pane-url');
+    renderHeader(headerApi('pane-url', 'Vite + React'), stubActions());
+
+    const url = container.querySelector('span[title="Vite + React"]');
+    expect(url?.textContent).toBe('localhost:5173/app');
+
+    registration.dispose();
+  });
+
+  it('badges a non-default --key but not the default key', () => {
+    const reg = register('pane-key', { ...CHROME, key: 'storybook' });
+    renderHeader(headerApi('pane-key', 'x'), stubActions());
+    expect(container.textContent).toContain('storybook');
+    reg.dispose();
+
+    act(() => root.unmount());
+    root = createRoot(container);
+
+    const reg2 = register('pane-key2', { ...CHROME, key: 'default' });
+    renderHeader(headerApi('pane-key2', 'x'), stubActions());
+    expect(container.querySelector('[title="dor ab --key default"]')).toBeNull();
+    reg2.dispose();
+  });
+
+  it('renders the dev-server chip and focuses the serving pane on click', () => {
+    const reg = register('pane-dev');
+    setDevServerResolution(5173, { paneId: 'term-9', label: 'pnpm dev' });
+    const onFocusPane = vi.fn();
+    renderHeader(headerApi('pane-dev', 'x'), stubActions({ onFocusPane }));
+
+    const chip = container.querySelector('button[aria-label="Focus pnpm dev — serves this localhost port"]');
+    expect(chip).not.toBeNull();
+    expect(chip?.textContent).toContain('pnpm dev');
+    expect(chip?.textContent).toContain(':5173');
+
+    act(() => {
+      chip?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    expect(onFocusPane).toHaveBeenCalledWith('term-9');
+
+    reg.dispose();
+  });
+
+  it('exposes back/forward/reload nav controls', () => {
+    const reg = register('pane-nav');
+    renderHeader(headerApi('pane-nav', 'x'), stubActions());
+    expect(container.querySelector('[aria-label="Back"]')).not.toBeNull();
+    expect(container.querySelector('[aria-label="Forward"]')).not.toBeNull();
+    expect(container.querySelector('[aria-label="Reload"]')).not.toBeNull();
+    reg.dispose();
+  });
+
+  it('falls back to a plain title (no nav) for non-browser surfaces', () => {
+    renderHeader(headerApi('pane-iframe', 'example.com'), stubActions());
+    expect(container.textContent).toContain('example.com');
+    expect(container.querySelector('[aria-label="Back"]')).toBeNull();
+    expect(container.querySelector('[aria-label="Reload"]')).toBeNull();
+  });
+});

--- a/lib/src/components/wall/SurfacePaneHeader.test.tsx
+++ b/lib/src/components/wall/SurfacePaneHeader.test.tsx
@@ -29,7 +29,6 @@ const CHROME: ChromeSnapshot = {
   displayUrl: 'localhost:5173/app',
   title: 'Vite + React',
   key: 'storybook',
-  connection: 'connected',
 };
 
 function stubActions(overrides: Partial<WallActions> = {}): WallActions {
@@ -126,6 +125,10 @@ describe('SurfacePaneHeader — browser chrome', () => {
     expect(chip).not.toBeNull();
     expect(chip?.textContent).toContain('pnpm dev');
     expect(chip?.textContent).toContain(':5173');
+
+    // With the chip fronting it, the URL drops the (redundant) domain and shows
+    // only the path.
+    expect(container.querySelector('span[title="Vite + React"]')?.textContent).toBe('/app');
 
     act(() => {
       chip?.dispatchEvent(new MouseEvent('click', { bubbles: true }));

--- a/lib/src/components/wall/SurfacePaneHeader.test.tsx
+++ b/lib/src/components/wall/SurfacePaneHeader.test.tsx
@@ -99,10 +99,12 @@ describe('SurfacePaneHeader — browser chrome', () => {
     registration.dispose();
   });
 
-  it('badges a non-default --key but not the default key', () => {
+  it('shows a key indicator for a non-default --key but not the default key', () => {
     const reg = register('pane-key', { ...CHROME, key: 'storybook' });
     renderHeader(headerApi('pane-key', 'x'), stubActions());
-    expect(container.textContent).toContain('storybook');
+    // Rendered as a filled key icon; the key name lives in the hover tooltip.
+    expect(container.querySelector('[aria-label="--key storybook"]')).not.toBeNull();
+    expect(container.textContent).not.toContain('storybook');
     reg.dispose();
 
     act(() => root.unmount());
@@ -110,7 +112,7 @@ describe('SurfacePaneHeader — browser chrome', () => {
 
     const reg2 = register('pane-key2', { ...CHROME, key: 'default' });
     renderHeader(headerApi('pane-key2', 'x'), stubActions());
-    expect(container.querySelector('[title="dor ab --key default"]')).toBeNull();
+    expect(container.querySelector('[aria-label="--key default"]')).toBeNull();
     reg2.dispose();
   });
 

--- a/lib/src/components/wall/SurfacePaneHeader.test.tsx
+++ b/lib/src/components/wall/SurfacePaneHeader.test.tsx
@@ -54,7 +54,7 @@ function register(id: string, chrome: ChromeSnapshot = CHROME) {
     snapshot: SCREEN,
     actions: { engageSync: vi.fn(), applyDevice: vi.fn(), applyViewport: vi.fn(), openModal: vi.fn() },
     chrome,
-    chromeActions: { back: vi.fn(), forward: vi.fn(), reload: vi.fn() },
+    chromeActions: { navigate: vi.fn(), back: vi.fn(), forward: vi.fn(), reload: vi.fn() },
     hostCapable: true,
   });
 }
@@ -144,6 +144,65 @@ describe('SurfacePaneHeader — browser chrome', () => {
     expect(container.querySelector('[aria-label="Forward"]')).not.toBeNull();
     expect(container.querySelector('[aria-label="Reload"]')).not.toBeNull();
     reg.dispose();
+  });
+
+  it('opens an inline editor on URL click and navigates (normalized) on Enter', () => {
+    const navigate = vi.fn();
+    const registration = registerAgentBrowserScreen('pane-url-edit', {
+      snapshot: SCREEN,
+      actions: { engageSync: vi.fn(), applyDevice: vi.fn(), applyViewport: vi.fn(), openModal: vi.fn() },
+      chrome: CHROME,
+      chromeActions: { navigate, back: vi.fn(), forward: vi.fn(), reload: vi.fn() },
+      hostCapable: true,
+    });
+    renderHeader(headerApi('pane-url-edit', 'x'), stubActions());
+
+    const urlSpan = container.querySelector('span[title="Vite + React"]') as HTMLElement;
+    expect(urlSpan).not.toBeNull();
+    act(() => { urlSpan.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+
+    // The editor is pre-filled with the full URL (not the host+path display).
+    const input = container.querySelector<HTMLInputElement>('[data-url-input-for="pane-url-edit"]');
+    expect(input).not.toBeNull();
+    expect(input!.value).toBe('http://localhost:5173/app');
+
+    act(() => {
+      input!.value = 'localhost:3000/x';
+      input!.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+    });
+    expect(navigate).toHaveBeenCalledWith('http://localhost:3000/x');
+    // Editor closes after navigating.
+    expect(container.querySelector('[data-url-input-for="pane-url-edit"]')).toBeNull();
+
+    registration.dispose();
+  });
+
+  it('cancels URL editing on Escape without navigating', () => {
+    const navigate = vi.fn();
+    const registration = registerAgentBrowserScreen('pane-url-esc', {
+      snapshot: SCREEN,
+      actions: { engageSync: vi.fn(), applyDevice: vi.fn(), applyViewport: vi.fn(), openModal: vi.fn() },
+      chrome: CHROME,
+      chromeActions: { navigate, back: vi.fn(), forward: vi.fn(), reload: vi.fn() },
+      hostCapable: true,
+    });
+    renderHeader(headerApi('pane-url-esc', 'x'), stubActions());
+
+    act(() => {
+      (container.querySelector('span[title="Vite + React"]') as HTMLElement)
+        .dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    const input = container.querySelector<HTMLInputElement>('[data-url-input-for="pane-url-esc"]');
+    expect(input).not.toBeNull();
+
+    act(() => {
+      input!.value = 'example.com';
+      input!.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+    });
+    expect(navigate).not.toHaveBeenCalled();
+    expect(container.querySelector('[data-url-input-for="pane-url-esc"]')).toBeNull();
+
+    registration.dispose();
   });
 
   it('falls back to a plain title (no nav) for non-browser surfaces', () => {

--- a/lib/src/components/wall/SurfacePaneHeader.test.tsx
+++ b/lib/src/components/wall/SurfacePaneHeader.test.tsx
@@ -101,9 +101,8 @@ describe('SurfacePaneHeader — browser chrome', () => {
   it('shows a key indicator for a non-default --key but not the default key', () => {
     const reg = register('pane-key', { ...CHROME, key: 'storybook' });
     renderHeader(headerApi('pane-key', 'x'), stubActions());
-    // Rendered as a filled key icon; the key name lives in the hover tooltip.
-    expect(container.querySelector('[aria-label="--key storybook"]')).not.toBeNull();
-    expect(container.textContent).not.toContain('storybook');
+    // Rendered inline as the key name, with `--key <name>` in the hover tooltip.
+    expect(container.querySelector('[title="--key storybook"]')?.textContent).toBe('storybook');
     reg.dispose();
 
     act(() => root.unmount());
@@ -111,7 +110,7 @@ describe('SurfacePaneHeader — browser chrome', () => {
 
     const reg2 = register('pane-key2', { ...CHROME, key: 'default' });
     renderHeader(headerApi('pane-key2', 'x'), stubActions());
-    expect(container.querySelector('[aria-label="--key default"]')).toBeNull();
+    expect(container.querySelector('[title="--key default"]')).toBeNull();
     reg2.dispose();
   });
 

--- a/lib/src/components/wall/SurfacePaneHeader.tsx
+++ b/lib/src/components/wall/SurfacePaneHeader.tsx
@@ -21,7 +21,7 @@ import {
   useAgentBrowserScreenController,
   useAgentBrowserScreenSnapshot,
 } from './agent-browser-screen';
-import { loopbackPort } from './browser-url';
+import { loopbackPort, pathDisplay } from './browser-url';
 import { triggerDevServerRescan, useDevServerMatch } from './agent-browser-ports';
 import {
   ModeContext,
@@ -52,6 +52,10 @@ export function SurfacePaneHeader({ api }: IDockviewPanelHeaderProps) {
   const port = chrome ? loopbackPort(chrome.url) : null;
   const devServer = useDevServerMatch(port);
 
+  // With a dev-server chip in front, the chip already shows host:port, so the
+  // URL collapses to just the path; otherwise it's the full host+path.
+  const urlText = chrome ? (devServer ? pathDisplay(chrome.url) : chrome.displayUrl) : '';
+
   return (
     <div
       className={`flex h-full w-full cursor-grab items-center gap-1.5 ${TERMINAL_TOP_RADIUS_CLASS} pl-2 pr-[5px] text-sm leading-none font-mono select-none active:cursor-grabbing ${isActiveHeader ? 'bg-header-active-bg text-header-active-fg' : 'bg-header-inactive-bg text-header-inactive-fg'}`}
@@ -66,7 +70,7 @@ export function SurfacePaneHeader({ api }: IDockviewPanelHeaderProps) {
             onClick={(e) => { e.stopPropagation(); screen.actions.openModal(); }}
             aria-label={`Screen: ${screenSnapshot.state} — change viewport`}
             title={`Screen: ${screenSnapshot.state} — change viewport`}
-            className="flex h-5 min-w-5 shrink-0 items-center justify-center rounded text-current/70 transition-colors hover:bg-current/10 hover:text-current"
+            className="flex h-5 min-w-5 shrink-0 items-center justify-center rounded transition-colors hover:bg-current/10"
           >
             {screenSnapshot.state === 'SYNCED'
               ? <FrameCornersIcon size={14} />
@@ -102,7 +106,7 @@ export function SurfacePaneHeader({ api }: IDockviewPanelHeaderProps) {
               title. Raw --session surfaces show none. */}
           {chrome.key && chrome.key !== 'default' && (
             <span
-              className="flex h-5 min-w-5 shrink-0 items-center justify-center text-current/70"
+              className="flex h-5 min-w-5 shrink-0 items-center justify-center"
               title={`--key ${chrome.key}`}
               aria-label={`--key ${chrome.key}`}
             >
@@ -110,28 +114,31 @@ export function SurfacePaneHeader({ api }: IDockviewPanelHeaderProps) {
             </span>
           )}
 
-          {/* URL (host + path) is the primary text; HTML <title> → tooltip. */}
-          <span
-            className="min-w-0 truncate font-medium"
-            title={chrome.title ?? chrome.url ?? undefined}
-          >{chrome.displayUrl || api.title || api.id}</span>
-
-          {/* Dev-server connection chip — only when the port maps to a single
-              pane; click focuses that terminal. Degrades to just the URL
-              otherwise (non-loopback, no/ambiguous match, proxied domain). */}
+          {/* Dev-server connection chip — in front of the URL when the port maps
+              to a single pane; click focuses that terminal. The full command
+              shows by default (no fixed cap); it only truncates after the URL
+              path has, since the URL shrinks far faster. Absent (non-loopback,
+              no/ambiguous match, proxied domain) ⇒ no chip + full host+path. */}
           {devServer && (
             <button
               type="button"
               onClick={(e) => { e.stopPropagation(); actions.onFocusPane(devServer.paneId); }}
               aria-label={`Focus ${devServer.label} — serves this localhost port`}
               title={`localhost served by ${devServer.label}${port != null ? ` (:${port})` : ''} — click to focus`}
-              className="flex h-5 min-w-0 shrink-0 items-center gap-1 rounded px-1.5 text-xs text-current/70 transition-colors hover:bg-current/10 hover:text-current"
+              className="flex h-5 min-w-0 items-center gap-1 rounded px-1.5 text-xs transition-colors hover:bg-current/10"
             >
-              <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-success" />
-              <span className="max-w-[14ch] truncate">{devServer.label}</span>
-              {port != null && <span className="text-current/50">:{port}</span>}
+              <span className="min-w-0 truncate">{devServer.label}</span>
+              {port != null && <span className="shrink-0 text-current/70">:{port}</span>}
             </button>
           )}
+
+          {/* URL is the path only when a chip fronts it (domain is in the chip),
+              else the full host+path. HTML <title> / full URL → tooltip. It
+              gives up width (shrink-[10]) long before the command does. */}
+          <span
+            className="min-w-0 shrink-[10] truncate font-medium"
+            title={chrome.title ?? chrome.url ?? undefined}
+          >{urlText || api.title || api.id}</span>
 
           {/* Flexible spacer keeps the layout buttons right-aligned. */}
           <div className="min-w-0 flex-1" />

--- a/lib/src/components/wall/SurfacePaneHeader.tsx
+++ b/lib/src/components/wall/SurfacePaneHeader.tsx
@@ -8,6 +8,7 @@ import {
   ArrowsInIcon,
   ArrowsOutIcon,
   FrameCornersIcon,
+  KeyIcon,
   ResizeIcon,
   SplitHorizontalIcon,
   SplitVerticalIcon,
@@ -96,13 +97,17 @@ export function SurfacePaneHeader({ api }: IDockviewPanelHeaderProps) {
             ><ArrowClockwiseIcon size={14} /></HeaderActionButton>
           </div>
 
-          {/* --key badge for non-default keys only — a separate element, never a
-              prefix on the persisted title. Raw --session surfaces show none. */}
+          {/* --key indicator for non-default keys only — a filled key icon
+              (hover reveals `--key <name>`), never a prefix on the persisted
+              title. Raw --session surfaces show none. */}
           {chrome.key && chrome.key !== 'default' && (
             <span
-              className="shrink-0 rounded bg-current/10 px-1.5 py-0.5 text-[11px] leading-none text-current/80"
-              title={`dor ab --key ${chrome.key}`}
-            >{chrome.key}</span>
+              className="flex h-5 min-w-5 shrink-0 items-center justify-center text-current/70"
+              title={`--key ${chrome.key}`}
+              aria-label={`--key ${chrome.key}`}
+            >
+              <KeyIcon size={14} weight="fill" />
+            </span>
           )}
 
           {/* URL (host + path) is the primary text; HTML <title> → tooltip. */}

--- a/lib/src/components/wall/SurfacePaneHeader.tsx
+++ b/lib/src/components/wall/SurfacePaneHeader.tsx
@@ -21,7 +21,7 @@ import {
   useAgentBrowserScreenSnapshot,
 } from './agent-browser-screen';
 import { loopbackPort } from './browser-url';
-import { useDevServerMatch } from './agent-browser-ports';
+import { triggerDevServerRescan, useDevServerMatch } from './agent-browser-ports';
 import {
   ModeContext,
   SelectedIdContext,
@@ -90,7 +90,7 @@ export function SurfacePaneHeader({ api }: IDockviewPanelHeaderProps) {
             ><ArrowRightIcon size={14} /></HeaderActionButton>
             <HeaderActionButton
               className="flex h-5 min-w-5 items-center justify-center rounded transition-colors hover:bg-current/10"
-              onClick={(e) => { e.stopPropagation(); screen.chromeActions.reload(); }}
+              onClick={(e) => { e.stopPropagation(); screen.chromeActions.reload(); triggerDevServerRescan(); }}
               ariaLabel="Reload"
               tooltip="Reload"
             ><ArrowClockwiseIcon size={14} /></HeaderActionButton>

--- a/lib/src/components/wall/SurfacePaneHeader.tsx
+++ b/lib/src/components/wall/SurfacePaneHeader.tsx
@@ -8,7 +8,6 @@ import {
   ArrowsInIcon,
   ArrowsOutIcon,
   FrameCornersIcon,
-  KeyIcon,
   ResizeIcon,
   SplitHorizontalIcon,
   SplitVerticalIcon,
@@ -101,17 +100,14 @@ export function SurfacePaneHeader({ api }: IDockviewPanelHeaderProps) {
             ><ArrowClockwiseIcon size={14} /></HeaderActionButton>
           </div>
 
-          {/* --key indicator for non-default keys only — a filled key icon
-              (hover reveals `--key <name>`), never a prefix on the persisted
-              title. Raw --session surfaces show none. */}
+          {/* --key indicator for non-default keys only — the key name inline,
+              small + quiet (hover reveals `--key <name>`), never a prefix on the
+              persisted title. Raw --session surfaces show none. */}
           {chrome.key && chrome.key !== 'default' && (
             <span
-              className="flex h-5 min-w-5 shrink-0 items-center justify-center"
+              className="shrink-0 text-xs text-current/70"
               title={`--key ${chrome.key}`}
-              aria-label={`--key ${chrome.key}`}
-            >
-              <KeyIcon size={14} weight="fill" />
-            </span>
+            >{chrome.key}</span>
           )}
 
           {/* Dev-server connection chip — in front of the URL when the port maps

--- a/lib/src/components/wall/SurfacePaneHeader.tsx
+++ b/lib/src/components/wall/SurfacePaneHeader.tsx
@@ -1,7 +1,10 @@
 import { useContext } from 'react';
 import type { IDockviewPanelHeaderProps } from 'dockview-react';
 import {
+  ArrowClockwiseIcon,
+  ArrowLeftIcon,
   ArrowLineDownIcon,
+  ArrowRightIcon,
   ArrowsInIcon,
   ArrowsOutIcon,
   FrameCornersIcon,
@@ -13,9 +16,12 @@ import {
 import { HeaderActionButton } from '../HeaderActionButton';
 import { TERMINAL_TOP_RADIUS_CLASS } from '../design';
 import {
+  useAgentBrowserChromeSnapshot,
   useAgentBrowserScreenController,
   useAgentBrowserScreenSnapshot,
 } from './agent-browser-screen';
+import { loopbackPort } from './browser-url';
+import { useDevServerMatch } from './agent-browser-ports';
 import {
   ModeContext,
   SelectedIdContext,
@@ -33,30 +39,102 @@ export function SurfacePaneHeader({ api }: IDockviewPanelHeaderProps) {
   const isActiveHeader = mode === 'passthrough' && selectedId === api.id && windowFocused;
 
   // Presence of a screen controller for this pane is exactly what marks it an
-  // agent-browser surface — terminals/iframes never register one, so the chip
-  // is strictly scoped to browser surfaces.
+  // agent-browser surface — terminals/iframes never register one, so the whole
+  // browser chrome (nav + URL + connection) is strictly scoped to it.
   const screen = useAgentBrowserScreenController(api.id);
   const screenSnapshot = useAgentBrowserScreenSnapshot(screen);
+  const chrome = useAgentBrowserChromeSnapshot(screen);
+
+  // Dev-server connection: when the active tab is loopback, correlate its port
+  // to the Dormouse terminal pane serving it (resolved Wall-side). Hooks run
+  // unconditionally; a non-loopback/no-screen surface just yields null.
+  const port = chrome ? loopbackPort(chrome.url) : null;
+  const devServer = useDevServerMatch(port);
 
   return (
     <div
       className={`flex h-full w-full cursor-grab items-center gap-1.5 ${TERMINAL_TOP_RADIUS_CLASS} pl-2 pr-[5px] text-sm leading-none font-mono select-none active:cursor-grabbing ${isActiveHeader ? 'bg-header-active-bg text-header-active-fg' : 'bg-header-inactive-bg text-header-inactive-fg'}`}
       onMouseDown={() => actions.onClickPanel(api.id)}
     >
-      <span className="min-w-0 flex-1 truncate font-medium">{api.title ?? api.id}</span>
-      {screen && screenSnapshot && (
-        <button
-          type="button"
-          onClick={(e) => { e.stopPropagation(); screen.actions.openModal(); }}
-          aria-label={`Screen: ${screenSnapshot.state} — change viewport`}
-          title={`Screen: ${screenSnapshot.state} — change viewport`}
-          className="flex h-5 min-w-5 shrink-0 items-center justify-center rounded text-current/70 transition-colors hover:bg-current/10 hover:text-current"
-        >
-          {screenSnapshot.state === 'SYNCED'
-            ? <FrameCornersIcon size={14} />
-            : <ResizeIcon size={14} />}
-        </button>
+      {screen && screenSnapshot && chrome ? (
+        <>
+          {/* Sync chip → far left, out of the way of the nav controls. Opens
+              the screen modal; SYNCED/SCALED reflects reality. */}
+          <button
+            type="button"
+            onClick={(e) => { e.stopPropagation(); screen.actions.openModal(); }}
+            aria-label={`Screen: ${screenSnapshot.state} — change viewport`}
+            title={`Screen: ${screenSnapshot.state} — change viewport`}
+            className="flex h-5 min-w-5 shrink-0 items-center justify-center rounded text-current/70 transition-colors hover:bg-current/10 hover:text-current"
+          >
+            {screenSnapshot.state === 'SYNCED'
+              ? <FrameCornersIcon size={14} />
+              : <ResizeIcon size={14} />}
+          </button>
+
+          {/* Back / forward / refresh — native agent-browser commands; always
+              enabled (no canGoBack/Forward in the stream). Collapse before the
+              URL but after split/zoom. */}
+          <div className="hidden shrink-0 items-center gap-0.5 min-[360px]:flex">
+            <HeaderActionButton
+              className="flex h-5 min-w-5 items-center justify-center rounded transition-colors hover:bg-current/10"
+              onClick={(e) => { e.stopPropagation(); screen.chromeActions.back(); }}
+              ariaLabel="Back"
+              tooltip="Back"
+            ><ArrowLeftIcon size={14} /></HeaderActionButton>
+            <HeaderActionButton
+              className="flex h-5 min-w-5 items-center justify-center rounded transition-colors hover:bg-current/10"
+              onClick={(e) => { e.stopPropagation(); screen.chromeActions.forward(); }}
+              ariaLabel="Forward"
+              tooltip="Forward"
+            ><ArrowRightIcon size={14} /></HeaderActionButton>
+            <HeaderActionButton
+              className="flex h-5 min-w-5 items-center justify-center rounded transition-colors hover:bg-current/10"
+              onClick={(e) => { e.stopPropagation(); screen.chromeActions.reload(); }}
+              ariaLabel="Reload"
+              tooltip="Reload"
+            ><ArrowClockwiseIcon size={14} /></HeaderActionButton>
+          </div>
+
+          {/* --key badge for non-default keys only — a separate element, never a
+              prefix on the persisted title. Raw --session surfaces show none. */}
+          {chrome.key && chrome.key !== 'default' && (
+            <span
+              className="shrink-0 rounded bg-current/10 px-1.5 py-0.5 text-[11px] leading-none text-current/80"
+              title={`dor ab --key ${chrome.key}`}
+            >{chrome.key}</span>
+          )}
+
+          {/* URL (host + path) is the primary text; HTML <title> → tooltip. */}
+          <span
+            className="min-w-0 truncate font-medium"
+            title={chrome.title ?? chrome.url ?? undefined}
+          >{chrome.displayUrl || api.title || api.id}</span>
+
+          {/* Dev-server connection chip — only when the port maps to a single
+              pane; click focuses that terminal. Degrades to just the URL
+              otherwise (non-loopback, no/ambiguous match, proxied domain). */}
+          {devServer && (
+            <button
+              type="button"
+              onClick={(e) => { e.stopPropagation(); actions.onFocusPane(devServer.paneId); }}
+              aria-label={`Focus ${devServer.label} — serves this localhost port`}
+              title={`localhost served by ${devServer.label}${port != null ? ` (:${port})` : ''} — click to focus`}
+              className="flex h-5 min-w-0 shrink-0 items-center gap-1 rounded px-1.5 text-xs text-current/70 transition-colors hover:bg-current/10 hover:text-current"
+            >
+              <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-success" />
+              <span className="max-w-[14ch] truncate">{devServer.label}</span>
+              {port != null && <span className="text-current/50">:{port}</span>}
+            </button>
+          )}
+
+          {/* Flexible spacer keeps the layout buttons right-aligned. */}
+          <div className="min-w-0 flex-1" />
+        </>
+      ) : (
+        <span className="min-w-0 flex-1 truncate font-medium">{api.title ?? api.id}</span>
       )}
+
       <div className="ml-1 hidden shrink-0 items-center gap-0.5 min-[420px]:flex">
         <HeaderActionButton
           className="flex h-5 min-w-5 items-center justify-center rounded transition-colors hover:bg-current/10"

--- a/lib/src/components/wall/SurfacePaneHeader.tsx
+++ b/lib/src/components/wall/SurfacePaneHeader.tsx
@@ -1,4 +1,4 @@
-import { useContext } from 'react';
+import { useContext, useEffect, useState } from 'react';
 import type { IDockviewPanelHeaderProps } from 'dockview-react';
 import {
   ArrowClockwiseIcon,
@@ -20,9 +20,10 @@ import {
   useAgentBrowserScreenController,
   useAgentBrowserScreenSnapshot,
 } from './agent-browser-screen';
-import { loopbackPort, pathDisplay } from './browser-url';
+import { loopbackPort, normalizeNavUrl, pathDisplay } from './browser-url';
 import { triggerDevServerRescan, useDevServerMatch } from './agent-browser-ports';
 import {
+  DialogKeyboardContext,
   ModeContext,
   SelectedIdContext,
   WallActionsContext,
@@ -54,6 +55,27 @@ export function SurfacePaneHeader({ api }: IDockviewPanelHeaderProps) {
   // With a dev-server chip in front, the chip already shows host:port, so the
   // URL collapses to just the path; otherwise it's the full host+path.
   const urlText = chrome ? (devServer ? pathDisplay(chrome.url) : chrome.displayUrl) : '';
+
+  // Clicking the URL opens an inline editor (like renaming a terminal tab) to
+  // navigate elsewhere. While it's open we flag dialog-keyboard so the Wall's
+  // keyboard handler stands down (the panel's own key-forwarder skips editable
+  // targets); the editor closes itself when the surface stops being a browser.
+  const setDialogKeyboardActive = useContext(DialogKeyboardContext);
+  const [editingUrl, setEditingUrl] = useState(false);
+  useEffect(() => {
+    if (!editingUrl) return;
+    setDialogKeyboardActive(true);
+    return () => setDialogKeyboardActive(false);
+  }, [editingUrl, setDialogKeyboardActive]);
+  useEffect(() => {
+    if (!screen && editingUrl) setEditingUrl(false);
+  }, [screen, editingUrl]);
+
+  const submitUrl = (value: string) => {
+    const url = normalizeNavUrl(value);
+    if (url) screen?.chromeActions.navigate(url);
+    setEditingUrl(false);
+  };
 
   return (
     <div
@@ -110,34 +132,60 @@ export function SurfacePaneHeader({ api }: IDockviewPanelHeaderProps) {
             >{chrome.key}</span>
           )}
 
-          {/* Dev-server connection chip — in front of the URL when the port maps
-              to a single pane; click focuses that terminal. The full command
-              shows by default (no fixed cap); it only truncates after the URL
-              path has, since the URL shrinks far faster. Absent (non-loopback,
-              no/ambiguous match, proxied domain) ⇒ no chip + full host+path. */}
-          {devServer && (
-            <button
-              type="button"
-              onClick={(e) => { e.stopPropagation(); actions.onFocusPane(devServer.paneId); }}
-              aria-label={`Focus ${devServer.label} — serves this localhost port`}
-              title={`localhost served by ${devServer.label}${port != null ? ` (:${port})` : ''} — click to focus`}
-              className="flex h-5 min-w-0 items-center gap-1 rounded px-1.5 text-xs transition-colors hover:bg-current/10"
-            >
-              <span className="min-w-0 truncate">{devServer.label}</span>
-              {port != null && <span className="shrink-0 text-current/70">:{port}</span>}
-            </button>
+          {editingUrl ? (
+            /* Inline URL editor (like renaming a terminal tab): pre-filled with
+               the full URL + all selected, Enter navigates, Escape/blur cancels
+               (browser-omnibox style). Fills the URL+chip+spacer span. */
+            <input
+              data-url-input-for={api.id}
+              className="min-w-0 flex-1 border-none bg-transparent p-0 font-medium text-inherit outline-none"
+              defaultValue={chrome.url}
+              autoFocus
+              ref={(el) => el?.select()}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') submitUrl((e.target as HTMLInputElement).value);
+                else if (e.key === 'Escape') setEditingUrl(false);
+                e.stopPropagation();
+              }}
+              onBlur={() => setEditingUrl(false)}
+              onMouseDown={(e) => e.stopPropagation()}
+              onClick={(e) => e.stopPropagation()}
+            />
+          ) : (
+            <>
+              {/* Dev-server connection chip — in front of the URL when the port
+                  maps to a single pane; click focuses that terminal. The full
+                  command shows by default (no fixed cap); it only truncates
+                  after the URL path has, since the URL shrinks far faster.
+                  Absent ⇒ no chip + full host+path. */}
+              {devServer && (
+                <button
+                  type="button"
+                  onClick={(e) => { e.stopPropagation(); actions.onFocusPane(devServer.paneId); }}
+                  aria-label={`Focus ${devServer.label} — serves this localhost port`}
+                  title={`localhost served by ${devServer.label}${port != null ? ` (:${port})` : ''} — click to focus`}
+                  className="flex h-5 min-w-0 items-center gap-1 rounded px-1.5 text-xs transition-colors hover:bg-current/10"
+                >
+                  <span className="min-w-0 truncate">{devServer.label}</span>
+                  {port != null && <span className="shrink-0 text-current/70">:{port}</span>}
+                </button>
+              )}
+
+              {/* URL is the path only when a chip fronts it (domain is in the
+                  chip), else the full host+path. Click to edit/navigate; HTML
+                  <title> / full URL → tooltip. Gives up width (shrink-[10]) long
+                  before the command does. */}
+              <span
+                className="min-w-0 shrink-[10] cursor-text truncate font-medium underline-offset-2 hover:underline"
+                title={chrome.title ?? chrome.url ?? undefined}
+                onMouseDown={(e) => e.stopPropagation()}
+                onClick={(e) => { e.stopPropagation(); setEditingUrl(true); }}
+              >{urlText || api.title || api.id}</span>
+
+              {/* Flexible spacer keeps the layout buttons right-aligned. */}
+              <div className="min-w-0 flex-1" />
+            </>
           )}
-
-          {/* URL is the path only when a chip fronts it (domain is in the chip),
-              else the full host+path. HTML <title> / full URL → tooltip. It
-              gives up width (shrink-[10]) long before the command does. */}
-          <span
-            className="min-w-0 shrink-[10] truncate font-medium"
-            title={chrome.title ?? chrome.url ?? undefined}
-          >{urlText || api.title || api.id}</span>
-
-          {/* Flexible spacer keeps the layout buttons right-aligned. */}
-          <div className="min-w-0 flex-1" />
         </>
       ) : (
         <span className="min-w-0 flex-1 truncate font-medium">{api.title ?? api.id}</span>

--- a/lib/src/components/wall/agent-browser-ports.test.ts
+++ b/lib/src/components/wall/agent-browser-ports.test.ts
@@ -5,8 +5,10 @@ import {
   releaseDevServerPort,
   requestDevServerPort,
   setDevServerResolution,
+  subscribeDevServerRescan,
   subscribeDevServerResolutions,
   subscribeWantedDevServerPorts,
+  triggerDevServerRescan,
 } from './agent-browser-ports';
 
 describe('dev-server port store', () => {
@@ -50,6 +52,26 @@ describe('dev-server port store', () => {
     expect(notify).toHaveBeenCalledTimes(2);
 
     unsubscribe();
+  });
+
+  it('notifies rescan subscribers without touching resolutions', () => {
+    requestDevServerPort(7000);
+    setDevServerResolution(7000, { paneId: 'pane-r', label: 'pnpm dev' });
+
+    const notify = vi.fn();
+    const unsubscribe = subscribeDevServerRescan(notify);
+
+    triggerDevServerRescan();
+    expect(notify).toHaveBeenCalledTimes(1);
+    // The signal is optimistic: the current match stays put until a rescan
+    // actually overwrites it.
+    expect(getDevServerResolution(7000)).toEqual({ paneId: 'pane-r', label: 'pnpm dev' });
+
+    unsubscribe();
+    triggerDevServerRescan();
+    expect(notify).toHaveBeenCalledTimes(1);
+
+    releaseDevServerPort(7000);
   });
 
   it('clears a resolution once the last watcher releases the port', () => {

--- a/lib/src/components/wall/agent-browser-ports.test.ts
+++ b/lib/src/components/wall/agent-browser-ports.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  getDevServerResolution,
+  getWantedDevServerPorts,
+  releaseDevServerPort,
+  requestDevServerPort,
+  setDevServerResolution,
+  subscribeDevServerResolutions,
+  subscribeWantedDevServerPorts,
+} from './agent-browser-ports';
+
+describe('dev-server port store', () => {
+  it('reference-counts interest and notifies on the first/last watcher', () => {
+    const notify = vi.fn();
+    const unsubscribe = subscribeWantedDevServerPorts(notify);
+
+    requestDevServerPort(5173);
+    expect(getWantedDevServerPorts()).toContain(5173);
+    expect(notify).toHaveBeenCalledTimes(1);
+
+    // A second watcher on the same port is not a new "wanted" edge.
+    requestDevServerPort(5173);
+    expect(notify).toHaveBeenCalledTimes(1);
+
+    releaseDevServerPort(5173);
+    expect(getWantedDevServerPorts()).toContain(5173);
+    expect(notify).toHaveBeenCalledTimes(1);
+
+    releaseDevServerPort(5173);
+    expect(getWantedDevServerPorts()).not.toContain(5173);
+    expect(notify).toHaveBeenCalledTimes(2);
+
+    unsubscribe();
+  });
+
+  it('publishes resolutions and dedupes equal matches', () => {
+    const notify = vi.fn();
+    const unsubscribe = subscribeDevServerResolutions(notify);
+
+    setDevServerResolution(4000, { paneId: 'pane-a', label: 'pnpm dev' });
+    expect(getDevServerResolution(4000)).toEqual({ paneId: 'pane-a', label: 'pnpm dev' });
+    expect(notify).toHaveBeenCalledTimes(1);
+
+    // An equal match must not re-notify (keeps useSyncExternalStore stable).
+    setDevServerResolution(4000, { paneId: 'pane-a', label: 'pnpm dev' });
+    expect(notify).toHaveBeenCalledTimes(1);
+
+    setDevServerResolution(4000, null);
+    expect(getDevServerResolution(4000)).toBeNull();
+    expect(notify).toHaveBeenCalledTimes(2);
+
+    unsubscribe();
+  });
+
+  it('clears a resolution once the last watcher releases the port', () => {
+    requestDevServerPort(9999);
+    setDevServerResolution(9999, { paneId: 'pane-z', label: 'vite' });
+    expect(getDevServerResolution(9999)).not.toBeNull();
+
+    releaseDevServerPort(9999);
+    expect(getDevServerResolution(9999)).toBeNull();
+    expect(getWantedDevServerPorts()).not.toContain(9999);
+  });
+});

--- a/lib/src/components/wall/agent-browser-ports.ts
+++ b/lib/src/components/wall/agent-browser-ports.ts
@@ -1,0 +1,118 @@
+/**
+ * Dev-server port → terminal-pane correlation store
+ * (docs/specs/dor-agent-browser.md → "Dev-server connection").
+ *
+ * A browser surface header can't see other panes' open ports, so the
+ * correlation lives in the Wall: it watches which loopback ports headers are
+ * interested in (`useDevServerMatch` registers interest), resolves each one to
+ * the terminal pane serving it (via `getOpenPorts`), and writes the result
+ * back here. The header consumes the resolved `{ paneId, label }` and clicks
+ * focus that pane.
+ *
+ * Two reference-counted channels, both consumed via useSyncExternalStore:
+ *   1. "wanted" ports — the set of loopback ports headers want resolved; the
+ *      Wall's correlation hook reads this and recomputes on change.
+ *   2. "resolutions" — port → match | null (null = resolved, no single owner);
+ *      headers read their port's entry.
+ */
+import { useEffect } from 'react';
+import { useSyncExternalStore } from 'react';
+
+export interface DevServerMatch {
+  /** The Dormouse surface id of the terminal serving this port. */
+  paneId: string;
+  /** A concise label for that pane (e.g. `pnpm dev`). */
+  label: string;
+}
+
+// port → number of headers currently watching it. A header increments on mount
+// (or when its active URL becomes loopback) and decrements on unmount/URL
+// change, so the Wall only ever resolves ports something is actually showing.
+const wanted = new Map<number, number>();
+const wantedListeners = new Set<() => void>();
+
+// port → match | null. `null` means "resolved, but no single pane owns it"
+// (no match, or ambiguous); absent means "not resolved yet".
+const resolutions = new Map<number, DevServerMatch | null>();
+const resolutionListeners = new Set<() => void>();
+
+function emitWanted(): void {
+  for (const listener of wantedListeners) listener();
+}
+
+function emitResolutions(): void {
+  for (const listener of resolutionListeners) listener();
+}
+
+export function requestDevServerPort(port: number): void {
+  const next = (wanted.get(port) ?? 0) + 1;
+  wanted.set(port, next);
+  if (next === 1) emitWanted();
+}
+
+export function releaseDevServerPort(port: number): void {
+  const current = wanted.get(port);
+  if (!current) return;
+  if (current > 1) {
+    wanted.set(port, current - 1);
+    return;
+  }
+  wanted.delete(port);
+  // Drop the stale resolution so a later watcher re-resolves from scratch
+  // rather than briefly flashing a now-defunct pane.
+  const hadResolution = resolutions.delete(port);
+  emitWanted();
+  if (hadResolution) emitResolutions();
+}
+
+export function getWantedDevServerPorts(): number[] {
+  return [...wanted.keys()];
+}
+
+export function subscribeWantedDevServerPorts(listener: () => void): () => void {
+  wantedListeners.add(listener);
+  return () => {
+    wantedListeners.delete(listener);
+  };
+}
+
+function matchEqual(a: DevServerMatch | null, b: DevServerMatch | null): boolean {
+  if (a === b) return true;
+  if (!a || !b) return false;
+  return a.paneId === b.paneId && a.label === b.label;
+}
+
+export function setDevServerResolution(port: number, match: DevServerMatch | null): void {
+  const prev = resolutions.get(port);
+  // Keep the stored reference stable when nothing changed — useSyncExternalStore
+  // requires getSnapshot to return a consistent value or it re-renders forever.
+  if (prev !== undefined && matchEqual(prev, match)) return;
+  resolutions.set(port, match);
+  emitResolutions();
+}
+
+export function getDevServerResolution(port: number): DevServerMatch | null {
+  return resolutions.get(port) ?? null;
+}
+
+export function subscribeDevServerResolutions(listener: () => void): () => void {
+  resolutionListeners.add(listener);
+  return () => {
+    resolutionListeners.delete(listener);
+  };
+}
+
+/** Header hook: register interest in a loopback `port` (or none) and return the
+ *  pane currently serving it, or null while unresolved / unmatched. */
+export function useDevServerMatch(port: number | null): DevServerMatch | null {
+  useEffect(() => {
+    if (port == null) return;
+    requestDevServerPort(port);
+    return () => releaseDevServerPort(port);
+  }, [port]);
+
+  return useSyncExternalStore(
+    subscribeDevServerResolutions,
+    () => (port == null ? null : getDevServerResolution(port)),
+  );
+}

--- a/lib/src/components/wall/agent-browser-ports.ts
+++ b/lib/src/components/wall/agent-browser-ports.ts
@@ -102,6 +102,24 @@ export function subscribeDevServerResolutions(listener: () => void): () => void 
   };
 }
 
+// --- reload re-validate signal ---
+//
+// Once a port is matched the Wall stops rescanning it (the serving pane rarely
+// moves). A surface reload asks the Wall to re-validate its ports — optimistically,
+// so the current chip stays put until the rescan actually disagrees.
+const rescanListeners = new Set<() => void>();
+
+export function triggerDevServerRescan(): void {
+  for (const listener of rescanListeners) listener();
+}
+
+export function subscribeDevServerRescan(listener: () => void): () => void {
+  rescanListeners.add(listener);
+  return () => {
+    rescanListeners.delete(listener);
+  };
+}
+
 /** Header hook: register interest in a loopback `port` (or none) and return the
  *  pane currently serving it, or null while unresolved / unmatched. */
 export function useDevServerMatch(port: number | null): DevServerMatch | null {

--- a/lib/src/components/wall/agent-browser-screen.test.ts
+++ b/lib/src/components/wall/agent-browser-screen.test.ts
@@ -7,6 +7,8 @@ import {
   registerAgentBrowserScreen,
   subscribeAgentBrowserScreenModal,
   subscribeAgentBrowserScreenPresence,
+  type ChromeActions,
+  type ChromeSnapshot,
   type ScreenActions,
   type ScreenSnapshot,
 } from './agent-browser-screen';
@@ -19,8 +21,30 @@ const SNAPSHOT: ScreenSnapshot = {
   syncEngaged: true,
 };
 
+const CHROME: ChromeSnapshot = {
+  url: 'http://localhost:5173/',
+  displayUrl: 'localhost:5173',
+  title: 'Vite + React',
+  key: null,
+  connection: 'connected',
+};
+
 function stubActions(): ScreenActions {
   return { engageSync: vi.fn(), applyDevice: vi.fn(), applyViewport: vi.fn(), openModal: vi.fn() };
+}
+
+function stubChromeActions(): ChromeActions {
+  return { back: vi.fn(), forward: vi.fn(), reload: vi.fn() };
+}
+
+function register(id: string, overrides?: { hostCapable?: boolean }) {
+  return registerAgentBrowserScreen(id, {
+    snapshot: SNAPSHOT,
+    actions: stubActions(),
+    chrome: CHROME,
+    chromeActions: stubChromeActions(),
+    hostCapable: overrides?.hostCapable ?? true,
+  });
 }
 
 describe('agent-browser screen registry', () => {
@@ -32,16 +56,13 @@ describe('agent-browser screen registry', () => {
 
     expect(getAgentBrowserScreenController('pane-1')).toBeNull();
 
-    const registration = registerAgentBrowserScreen('pane-1', {
-      snapshot: SNAPSHOT,
-      actions: stubActions(),
-      hostCapable: true,
-    });
+    const registration = register('pane-1');
     expect(presence).toBe(1);
 
     const controller = getAgentBrowserScreenController('pane-1');
     expect(controller).not.toBeNull();
     expect(controller?.snapshot()).toEqual(SNAPSHOT);
+    expect(controller?.chrome()).toEqual(CHROME);
     expect(controller?.hostCapable).toBe(true);
 
     registration.dispose();
@@ -52,11 +73,7 @@ describe('agent-browser screen registry', () => {
   });
 
   it('publishes snapshot updates to subscribers', () => {
-    const registration = registerAgentBrowserScreen('pane-2', {
-      snapshot: SNAPSHOT,
-      actions: stubActions(),
-      hostCapable: false,
-    });
+    const registration = register('pane-2', { hostCapable: false });
     const controller = getAgentBrowserScreenController('pane-2')!;
 
     let updates = 0;
@@ -73,17 +90,34 @@ describe('agent-browser screen registry', () => {
     registration.dispose();
   });
 
+  it('publishes chrome updates on a channel separate from the screen snapshot', () => {
+    const registration = register('pane-chrome');
+    const controller = getAgentBrowserScreenController('pane-chrome')!;
+
+    let screenUpdates = 0;
+    let chromeUpdates = 0;
+    const unsubScreen = controller.subscribe(() => { screenUpdates += 1; });
+    const unsubChrome = controller.subscribeChrome(() => { chromeUpdates += 1; });
+
+    const nextChrome: ChromeSnapshot = { ...CHROME, displayUrl: 'localhost:5173/app', connection: 'connecting' };
+    registration.updateChrome(nextChrome);
+    expect(controller.chrome()).toEqual(nextChrome);
+    expect(chromeUpdates).toBe(1);
+    // A chrome change must NOT wake the screen subscribers, and vice versa.
+    expect(screenUpdates).toBe(0);
+
+    registration.update({ ...SNAPSHOT, state: 'SYNCED' });
+    expect(screenUpdates).toBe(1);
+    expect(chromeUpdates).toBe(1);
+
+    unsubScreen();
+    unsubChrome();
+    registration.dispose();
+  });
+
   it('a stale registration does not clobber a re-registered surface on dispose', () => {
-    const first = registerAgentBrowserScreen('pane-3', {
-      snapshot: SNAPSHOT,
-      actions: stubActions(),
-      hostCapable: true,
-    });
-    const second = registerAgentBrowserScreen('pane-3', {
-      snapshot: SNAPSHOT,
-      actions: stubActions(),
-      hostCapable: true,
-    });
+    const first = register('pane-3');
+    const second = register('pane-3');
     const live = getAgentBrowserScreenController('pane-3');
 
     // Disposing the superseded registration must not remove the live one.

--- a/lib/src/components/wall/agent-browser-screen.test.ts
+++ b/lib/src/components/wall/agent-browser-screen.test.ts
@@ -26,7 +26,6 @@ const CHROME: ChromeSnapshot = {
   displayUrl: 'localhost:5173',
   title: 'Vite + React',
   key: null,
-  connection: 'connected',
 };
 
 function stubActions(): ScreenActions {
@@ -99,7 +98,7 @@ describe('agent-browser screen registry', () => {
     const unsubScreen = controller.subscribe(() => { screenUpdates += 1; });
     const unsubChrome = controller.subscribeChrome(() => { chromeUpdates += 1; });
 
-    const nextChrome: ChromeSnapshot = { ...CHROME, displayUrl: 'localhost:5173/app', connection: 'connecting' };
+    const nextChrome: ChromeSnapshot = { ...CHROME, displayUrl: 'localhost:5173/app', title: 'Vite' };
     registration.updateChrome(nextChrome);
     expect(controller.chrome()).toEqual(nextChrome);
     expect(chromeUpdates).toBe(1);

--- a/lib/src/components/wall/agent-browser-screen.test.ts
+++ b/lib/src/components/wall/agent-browser-screen.test.ts
@@ -33,7 +33,7 @@ function stubActions(): ScreenActions {
 }
 
 function stubChromeActions(): ChromeActions {
-  return { back: vi.fn(), forward: vi.fn(), reload: vi.fn() };
+  return { navigate: vi.fn(), back: vi.fn(), forward: vi.fn(), reload: vi.fn() };
 }
 
 function register(id: string, overrides?: { hostCapable?: boolean }) {

--- a/lib/src/components/wall/agent-browser-screen.ts
+++ b/lib/src/components/wall/agent-browser-screen.ts
@@ -60,6 +60,8 @@ export interface ChromeSnapshot {
 }
 
 export interface ChromeActions {
+  /** Native `open <url>` — navigate the active tab to a new URL. */
+  navigate(url: string): void;
   /** Native `back` — move history back one entry (no-op at the start). */
   back(): void;
   /** Native `forward` — move history forward one entry (no-op at the end). */

--- a/lib/src/components/wall/agent-browser-screen.ts
+++ b/lib/src/components/wall/agent-browser-screen.ts
@@ -42,11 +42,46 @@ export interface ScreenActions {
   openModal(): void;
 }
 
+export type ChromeConnection = 'connected' | 'connecting' | 'lost';
+
+/** What the browser-chrome header reads about the active tab + session
+ *  (docs/specs/dor-agent-browser.md → "Browser-chrome header"). Updated on its
+ *  own cadence (tab/status stream messages), separate from the screen snapshot
+ *  which churns on resize. */
+export interface ChromeSnapshot {
+  /** Active tab's full URL — used to extract the loopback port + as a tooltip
+   *  fallback. */
+  url: string;
+  /** Active tab's host+path (header primary text). */
+  displayUrl: string;
+  /** Active tab's HTML `<title>` (header tooltip), or null. */
+  title: string | null;
+  /** Managed `--key` for this surface, or null for raw `--session` / no key.
+   *  The header shows a badge for non-`default` keys only. */
+  key: string | null;
+  /** Live connection state of the session stream. */
+  connection: ChromeConnection;
+}
+
+export interface ChromeActions {
+  /** Native `back` — move history back one entry (no-op at the start). */
+  back(): void;
+  /** Native `forward` — move history forward one entry (no-op at the end). */
+  forward(): void;
+  /** Native `reload` — reload the active tab. */
+  reload(): void;
+}
+
 export interface ScreenController {
   readonly id: string;
   subscribe(listener: () => void): () => void;
   snapshot(): ScreenSnapshot;
   readonly actions: ScreenActions;
+  /** Browser-chrome (URL / key / connection) channel — separate subscription so
+   *  tab/status updates don't churn the screen snapshot and vice versa. */
+  subscribeChrome(listener: () => void): () => void;
+  chrome(): ChromeSnapshot;
+  readonly chromeActions: ChromeActions;
   /** Whether the host can run `agentBrowserCommand` (false ⇒ resizes inert). */
   readonly hostCapable: boolean;
 }
@@ -54,6 +89,8 @@ export interface ScreenController {
 interface ScreenEntry {
   snapshot: ScreenSnapshot;
   listeners: Set<() => void>;
+  chrome: ChromeSnapshot;
+  chromeListeners: Set<() => void>;
   controller: ScreenController;
 }
 
@@ -69,19 +106,31 @@ export interface ScreenRegistration {
    *  object only when something actually changed (the panel gates on flip /
    *  dim change to avoid thrashing the header per frame). */
   update(snapshot: ScreenSnapshot): void;
+  /** Push a new browser-chrome snapshot (URL / key / connection); notifies the
+   *  chrome subscribers. Gated by the panel on its tab/status effects. */
+  updateChrome(chrome: ChromeSnapshot): void;
   dispose(): void;
 }
 
-/** Register a surface's screen controller (panel mount). `actions` must be a
- *  stable object whose methods read the panel's current closures (e.g. via
- *  refs), so the controller never goes stale across panel re-renders. */
+/** Register a surface's screen controller (panel mount). `actions` /
+ *  `chromeActions` must be stable objects whose methods read the panel's
+ *  current closures (e.g. via refs), so the controller never goes stale across
+ *  panel re-renders. */
 export function registerAgentBrowserScreen(
   id: string,
-  init: { snapshot: ScreenSnapshot; actions: ScreenActions; hostCapable: boolean },
+  init: {
+    snapshot: ScreenSnapshot;
+    actions: ScreenActions;
+    chrome: ChromeSnapshot;
+    chromeActions: ChromeActions;
+    hostCapable: boolean;
+  },
 ): ScreenRegistration {
   const entry: ScreenEntry = {
     snapshot: init.snapshot,
     listeners: new Set(),
+    chrome: init.chrome,
+    chromeListeners: new Set(),
     controller: {
       id,
       subscribe(listener) {
@@ -90,6 +139,12 @@ export function registerAgentBrowserScreen(
       },
       snapshot: () => entry.snapshot,
       actions: init.actions,
+      subscribeChrome(listener) {
+        entry.chromeListeners.add(listener);
+        return () => entry.chromeListeners.delete(listener);
+      },
+      chrome: () => entry.chrome,
+      chromeActions: init.chromeActions,
       hostCapable: init.hostCapable,
     },
   };
@@ -99,6 +154,10 @@ export function registerAgentBrowserScreen(
     update(snapshot) {
       entry.snapshot = snapshot;
       for (const listener of entry.listeners) listener();
+    },
+    updateChrome(chrome) {
+      entry.chrome = chrome;
+      for (const listener of entry.chromeListeners) listener();
     },
     dispose() {
       if (registry.get(id) === entry) {
@@ -171,6 +230,15 @@ export function useAgentBrowserScreenSnapshot(controller: ScreenController | nul
   return useSyncExternalStore(
     controller ? controller.subscribe : NO_SUBSCRIBE,
     () => controller?.snapshot() ?? null,
+  );
+}
+
+/** A controller's live browser-chrome snapshot (URL / key / connection), or
+ *  null for a non-browser surface. Re-renders only on tab/status changes. */
+export function useAgentBrowserChromeSnapshot(controller: ScreenController | null): ChromeSnapshot | null {
+  return useSyncExternalStore(
+    controller ? controller.subscribeChrome : NO_SUBSCRIBE,
+    () => controller?.chrome() ?? null,
   );
 }
 

--- a/lib/src/components/wall/agent-browser-screen.ts
+++ b/lib/src/components/wall/agent-browser-screen.ts
@@ -42,12 +42,10 @@ export interface ScreenActions {
   openModal(): void;
 }
 
-export type ChromeConnection = 'connected' | 'connecting' | 'lost';
-
-/** What the browser-chrome header reads about the active tab + session
+/** What the browser-chrome header reads about the active tab
  *  (docs/specs/dor-agent-browser.md → "Browser-chrome header"). Updated on its
- *  own cadence (tab/status stream messages), separate from the screen snapshot
- *  which churns on resize. */
+ *  own cadence (tab stream messages), separate from the screen snapshot which
+ *  churns on resize. */
 export interface ChromeSnapshot {
   /** Active tab's full URL — used to extract the loopback port + as a tooltip
    *  fallback. */
@@ -59,8 +57,6 @@ export interface ChromeSnapshot {
   /** Managed `--key` for this surface, or null for raw `--session` / no key.
    *  The header shows a badge for non-`default` keys only. */
   key: string | null;
-  /** Live connection state of the session stream. */
-  connection: ChromeConnection;
 }
 
 export interface ChromeActions {
@@ -77,8 +73,8 @@ export interface ScreenController {
   subscribe(listener: () => void): () => void;
   snapshot(): ScreenSnapshot;
   readonly actions: ScreenActions;
-  /** Browser-chrome (URL / key / connection) channel — separate subscription so
-   *  tab/status updates don't churn the screen snapshot and vice versa. */
+  /** Browser-chrome (URL / key) channel — separate subscription so
+   *  tab updates don't churn the screen snapshot and vice versa. */
   subscribeChrome(listener: () => void): () => void;
   chrome(): ChromeSnapshot;
   readonly chromeActions: ChromeActions;
@@ -106,8 +102,8 @@ export interface ScreenRegistration {
    *  object only when something actually changed (the panel gates on flip /
    *  dim change to avoid thrashing the header per frame). */
   update(snapshot: ScreenSnapshot): void;
-  /** Push a new browser-chrome snapshot (URL / key / connection); notifies the
-   *  chrome subscribers. Gated by the panel on its tab/status effects. */
+  /** Push a new browser-chrome snapshot (URL / key); notifies the
+   *  chrome subscribers. Gated by the panel on its tab effects. */
   updateChrome(chrome: ChromeSnapshot): void;
   dispose(): void;
 }
@@ -233,7 +229,7 @@ export function useAgentBrowserScreenSnapshot(controller: ScreenController | nul
   );
 }
 
-/** A controller's live browser-chrome snapshot (URL / key / connection), or
+/** A controller's live browser-chrome snapshot (URL / key), or
  *  null for a non-browser surface. Re-renders only on tab/status changes. */
 export function useAgentBrowserChromeSnapshot(controller: ScreenController | null): ChromeSnapshot | null {
   return useSyncExternalStore(

--- a/lib/src/components/wall/browser-url.test.ts
+++ b/lib/src/components/wall/browser-url.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import { hostPathDisplay, loopbackPort } from './browser-url';
+
+describe('hostPathDisplay', () => {
+  it('drops the scheme and a bare root path', () => {
+    expect(hostPathDisplay('http://localhost:5173/')).toBe('localhost:5173');
+    expect(hostPathDisplay('https://example.com')).toBe('example.com');
+  });
+
+  it('keeps a non-root path but not the query/hash', () => {
+    expect(hostPathDisplay('http://localhost:5173/app/page?x=1#frag')).toBe('localhost:5173/app/page');
+  });
+
+  it('falls back to the raw string when unparseable', () => {
+    expect(hostPathDisplay('not a url')).toBe('not a url');
+    expect(hostPathDisplay('')).toBe('');
+  });
+});
+
+describe('loopbackPort', () => {
+  it('extracts the port from loopback hosts', () => {
+    expect(loopbackPort('http://localhost:5173/')).toBe(5173);
+    expect(loopbackPort('http://127.0.0.1:6006')).toBe(6006);
+    expect(loopbackPort('http://app.localhost:3000')).toBe(3000);
+    expect(loopbackPort('http://[::1]:8080/')).toBe(8080);
+  });
+
+  it('defaults the port from the scheme when absent', () => {
+    expect(loopbackPort('http://localhost')).toBe(80);
+    expect(loopbackPort('https://localhost')).toBe(443);
+  });
+
+  it('returns null for non-loopback hosts', () => {
+    expect(loopbackPort('http://example.com:5173')).toBeNull();
+    expect(loopbackPort('http://192.168.1.5:5173')).toBeNull();
+  });
+
+  it('returns null for unparseable input', () => {
+    expect(loopbackPort('localhost:5173')).toBeNull();
+    expect(loopbackPort('')).toBeNull();
+  });
+});

--- a/lib/src/components/wall/browser-url.test.ts
+++ b/lib/src/components/wall/browser-url.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { hostPathDisplay, loopbackPort } from './browser-url';
+import { hostPathDisplay, loopbackPort, pathDisplay } from './browser-url';
 
 describe('hostPathDisplay', () => {
   it('drops the scheme and a bare root path', () => {
@@ -14,6 +14,23 @@ describe('hostPathDisplay', () => {
   it('falls back to the raw string when unparseable', () => {
     expect(hostPathDisplay('not a url')).toBe('not a url');
     expect(hostPathDisplay('')).toBe('');
+  });
+});
+
+describe('pathDisplay', () => {
+  it('returns the path only, dropping scheme/host', () => {
+    expect(pathDisplay('http://localhost:5173/app')).toBe('/app');
+    expect(pathDisplay('http://localhost:5173/app/page')).toBe('/app/page');
+  });
+
+  it('returns "/" for a root URL', () => {
+    expect(pathDisplay('http://localhost:5173/')).toBe('/');
+    expect(pathDisplay('http://localhost:5173')).toBe('/');
+  });
+
+  it('falls back to the raw string when unparseable', () => {
+    expect(pathDisplay('not a url')).toBe('not a url');
+    expect(pathDisplay('')).toBe('');
   });
 });
 

--- a/lib/src/components/wall/browser-url.test.ts
+++ b/lib/src/components/wall/browser-url.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { hostPathDisplay, loopbackPort, pathDisplay } from './browser-url';
+import { hostPathDisplay, loopbackPort, normalizeNavUrl, pathDisplay } from './browser-url';
 
 describe('hostPathDisplay', () => {
   it('drops the scheme and a bare root path', () => {
@@ -31,6 +31,31 @@ describe('pathDisplay', () => {
   it('falls back to the raw string when unparseable', () => {
     expect(pathDisplay('not a url')).toBe('not a url');
     expect(pathDisplay('')).toBe('');
+  });
+});
+
+describe('normalizeNavUrl', () => {
+  it('keeps an explicit scheme untouched', () => {
+    expect(normalizeNavUrl('https://example.com')).toBe('https://example.com');
+    expect(normalizeNavUrl('http://localhost:5173/app')).toBe('http://localhost:5173/app');
+    expect(normalizeNavUrl('about:blank')).toBe('about:blank');
+  });
+
+  it('adds http:// for loopback hosts (https just SSL-errors there)', () => {
+    expect(normalizeNavUrl('localhost:5173')).toBe('http://localhost:5173');
+    expect(normalizeNavUrl('127.0.0.1:6006/x')).toBe('http://127.0.0.1:6006/x');
+    expect(normalizeNavUrl('app.localhost:3000')).toBe('http://app.localhost:3000');
+  });
+
+  it('adds https:// for everything else', () => {
+    expect(normalizeNavUrl('example.com')).toBe('https://example.com');
+    expect(normalizeNavUrl('example.com/path?q=1')).toBe('https://example.com/path?q=1');
+  });
+
+  it('trims and treats empty input as no navigation', () => {
+    expect(normalizeNavUrl('   ')).toBe('');
+    expect(normalizeNavUrl('')).toBe('');
+    expect(normalizeNavUrl('  example.com  ')).toBe('https://example.com');
   });
 });
 

--- a/lib/src/components/wall/browser-url.test.ts
+++ b/lib/src/components/wall/browser-url.test.ts
@@ -11,6 +11,11 @@ describe('hostPathDisplay', () => {
     expect(hostPathDisplay('http://localhost:5173/app/page?x=1#frag')).toBe('localhost:5173/app/page');
   });
 
+  it('includes the query when asked (iframe titles do)', () => {
+    expect(hostPathDisplay('http://localhost:5173/app?x=1', true)).toBe('localhost:5173/app?x=1');
+    expect(hostPathDisplay('http://localhost:5173/?id=story', true)).toBe('localhost:5173?id=story');
+  });
+
   it('falls back to the raw string when unparseable', () => {
     expect(hostPathDisplay('not a url')).toBe('not a url');
     expect(hostPathDisplay('')).toBe('');

--- a/lib/src/components/wall/browser-url.ts
+++ b/lib/src/components/wall/browser-url.ts
@@ -31,6 +31,29 @@ export function pathDisplay(rawUrl: string): string {
   }
 }
 
+/** Turn a typed address-bar value into a navigable URL: keep an explicit scheme,
+ *  otherwise add one — `http://` for loopback hosts (a bare `localhost:5173`
+ *  speaks http, and `https` there just SSL-errors), `https://` for everything
+ *  else. Empty input ⇒ '' (caller skips navigation). */
+export function normalizeNavUrl(raw: string): string {
+  const trimmed = raw.trim();
+  if (!trimmed) return '';
+  // A hierarchical scheme (http://, https://, file://, …) or a known schemeless
+  // one (about:, data:, mailto:, …) — leave it be. A bare `host:port` such as
+  // `localhost:5173` is NOT a scheme (no `//`), so it falls through to get one.
+  if (/^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//.test(trimmed)) return trimmed;
+  if (/^(about|data|blob|mailto|tel|javascript|view-source|chrome):/i.test(trimmed)) return trimmed;
+  const host = trimmed.split(/[/?#]/, 1)[0].toLowerCase();
+  const hostname = host.split(':', 1)[0];
+  const isLoopback =
+    hostname === 'localhost' ||
+    hostname === '127.0.0.1' ||
+    hostname === '[::1]' ||
+    hostname === '::1' ||
+    hostname.endsWith('.localhost');
+  return `${isLoopback ? 'http' : 'https'}://${trimmed}`;
+}
+
 /** True for hostnames that resolve to the local machine. `*.localhost` is
  *  included because browsers route it to loopback per the RFC. */
 function isLoopbackHostname(hostname: string): boolean {

--- a/lib/src/components/wall/browser-url.ts
+++ b/lib/src/components/wall/browser-url.ts
@@ -1,0 +1,54 @@
+/**
+ * Small URL helpers for the agent-browser surface header
+ * (see docs/specs/dor-agent-browser.md → "Browser-chrome header").
+ *
+ * The header shows a tab's URL as host+path (Chrome-style, the scheme and any
+ * query/hash dropped) and, when that URL is loopback, correlates its port to a
+ * Dormouse terminal pane. Both jobs are pure string parsing kept out of the
+ * components so they can be unit-tested directly.
+ */
+
+/** Host + path of a URL (e.g. `localhost:5173/app`), the header's primary text.
+ *  Falls back to the raw string for anything `URL` can't parse. */
+export function hostPathDisplay(rawUrl: string): string {
+  try {
+    const parsed = new URL(rawUrl);
+    const path = parsed.pathname === '/' ? '' : parsed.pathname;
+    return `${parsed.host}${path}` || rawUrl;
+  } catch {
+    return rawUrl || '';
+  }
+}
+
+/** True for hostnames that resolve to the local machine. `*.localhost` is
+ *  included because browsers route it to loopback per the RFC. */
+function isLoopbackHostname(hostname: string): boolean {
+  const host = hostname.toLowerCase();
+  return (
+    host === 'localhost' ||
+    host === '127.0.0.1' ||
+    host === '::1' ||
+    host === '[::1]' ||
+    host.endsWith('.localhost')
+  );
+}
+
+/** The TCP port of a loopback URL, or null if the URL is not loopback / has no
+ *  resolvable port. Defaults the port from the scheme (http→80, https→443) so a
+ *  bare `http://localhost` still correlates. */
+export function loopbackPort(rawUrl: string): number | null {
+  try {
+    const parsed = new URL(rawUrl);
+    if (!isLoopbackHostname(parsed.hostname)) return null;
+    const port = parsed.port
+      ? Number(parsed.port)
+      : parsed.protocol === 'https:'
+        ? 443
+        : parsed.protocol === 'http:'
+          ? 80
+          : NaN;
+    return Number.isInteger(port) && port > 0 && port <= 65535 ? port : null;
+  } catch {
+    return null;
+  }
+}

--- a/lib/src/components/wall/browser-url.ts
+++ b/lib/src/components/wall/browser-url.ts
@@ -43,15 +43,8 @@ export function normalizeNavUrl(raw: string): string {
   // `localhost:5173` is NOT a scheme (no `//`), so it falls through to get one.
   if (/^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//.test(trimmed)) return trimmed;
   if (/^(about|data|blob|mailto|tel|javascript|view-source|chrome):/i.test(trimmed)) return trimmed;
-  const host = trimmed.split(/[/?#]/, 1)[0].toLowerCase();
-  const hostname = host.split(':', 1)[0];
-  const isLoopback =
-    hostname === 'localhost' ||
-    hostname === '127.0.0.1' ||
-    hostname === '[::1]' ||
-    hostname === '::1' ||
-    hostname.endsWith('.localhost');
-  return `${isLoopback ? 'http' : 'https'}://${trimmed}`;
+  const hostname = trimmed.split(/[/?#]/, 1)[0].split(':', 1)[0];
+  return `${isLoopbackHostname(hostname) ? 'http' : 'https'}://${trimmed}`;
 }
 
 /** True for hostnames that resolve to the local machine. `*.localhost` is

--- a/lib/src/components/wall/browser-url.ts
+++ b/lib/src/components/wall/browser-url.ts
@@ -8,13 +8,15 @@
  * components so they can be unit-tested directly.
  */
 
-/** Host + path of a URL (e.g. `localhost:5173/app`), the header's primary text.
- *  Falls back to the raw string for anything `URL` can't parse. */
-export function hostPathDisplay(rawUrl: string): string {
+/** Host + path of a URL (e.g. `localhost:5173/app`) — the browser header's
+ *  primary text, and the iframe surface's title. Pass `includeSearch` to keep
+ *  the query string (iframes do; the browser header drops it). Falls back to the
+ *  raw string for anything `URL` can't parse. */
+export function hostPathDisplay(rawUrl: string, includeSearch = false): string {
   try {
     const parsed = new URL(rawUrl);
     const path = parsed.pathname === '/' ? '' : parsed.pathname;
-    return `${parsed.host}${path}` || rawUrl;
+    return `${parsed.host}${path}${includeSearch ? parsed.search : ''}` || rawUrl;
   } catch {
     return rawUrl || '';
   }

--- a/lib/src/components/wall/browser-url.ts
+++ b/lib/src/components/wall/browser-url.ts
@@ -20,6 +20,17 @@ export function hostPathDisplay(rawUrl: string): string {
   }
 }
 
+/** Path only (e.g. `/app`), used when a dev-server chip already shows the
+ *  host+port so the domain would be redundant. Falls back to the raw string for
+ *  anything `URL` can't parse. */
+export function pathDisplay(rawUrl: string): string {
+  try {
+    return new URL(rawUrl).pathname || '/';
+  } catch {
+    return rawUrl || '';
+  }
+}
+
 /** True for hostnames that resolve to the local machine. `*.localhost` is
  *  included because browsers route it to loopback per the RFC. */
 function isLoopbackHostname(hostname: string): boolean {

--- a/lib/src/components/wall/keyboard/handle-mouse-selection-keys.ts
+++ b/lib/src/components/wall/keyboard/handle-mouse-selection-keys.ts
@@ -1,4 +1,5 @@
 import { copyRaw, copyRewrapped, doPaste } from '../../../lib/clipboard';
+import { isEditableTarget } from '../../../lib/dom';
 import { IS_MAC } from '../../../lib/platform';
 import {
   extendSelectionToToken,
@@ -18,12 +19,7 @@ export function handleMouseSelectionKeys(e: KeyboardEvent, ctx: WallKeyboardCtx)
   // copy/paste there. Xterm's hidden helper textarea is the input proxy
   // for the terminal itself, so we keep intercepting its keydowns.
   const tgt = e.target as HTMLElement | null;
-  if (
-    tgt &&
-    (tgt.tagName === 'INPUT' ||
-      (tgt.tagName === 'TEXTAREA' && !tgt.classList.contains('xterm-helper-textarea')) ||
-      tgt.isContentEditable)
-  ) {
+  if (isEditableTarget(tgt) && !tgt?.classList.contains('xterm-helper-textarea')) {
     return false;
   }
 

--- a/lib/src/components/wall/use-dev-server-ports.ts
+++ b/lib/src/components/wall/use-dev-server-ports.ts
@@ -8,10 +8,20 @@
  * (`getOpenPorts`), find the single pane serving that port, and publish back
  * `{ paneId, label }`.
  *
- * Cost control (per the spec): only runs while at least one loopback port is
- * wanted, resolves promptly when new interest appears, and otherwise refreshes
- * on a slow interval. `getOpenPorts` has a ~3s timeout, so a stuck pane can't
- * wedge the loop — `runningRef` keeps at most one sweep in flight.
+ * This is **purely decorative and strictly off the hot path.** `getOpenPorts`
+ * shells out (per-OS `lsof`/PowerShell) on the host that also drives the live
+ * screencast, so a scan triggered the instant a tab opens would contend with
+ * that tab's first screenshots. So resolution is:
+ *   - **deferred & debounced** — a loopback URL appearing schedules a scan a
+ *     beat later, coalescing rapid navigation, so tab-open finishes first;
+ *   - **idle-scheduled** — the scan runs in `requestIdleCallback` time (with a
+ *     timeout fallback), yielding to rendering and the screencast;
+ *   - **adaptively paced** — it polls only while a loopback port is on screen,
+ *     quickly while a port is still unmatched (a dev server may start after the
+ *     tab), then backs off to a slow refresh once matched, and stops entirely
+ *     when nothing is wanted.
+ * At most one scan is in flight (`running`), and `getOpenPorts`' own ~3s timeout
+ * keeps a stuck pane from wedging the loop.
  */
 import { useEffect } from 'react';
 import type { DockviewApi } from 'dockview-react';
@@ -19,6 +29,7 @@ import { getPlatform } from '../../lib/platform';
 import { getActivitySnapshot, getTerminalPaneStateSnapshot } from '../../lib/terminal-registry';
 import { buildAppTitleResolver, deriveHeader, resolveDisplayPrimary } from '../../lib/terminal-state';
 import {
+  getDevServerResolution,
   getWantedDevServerPorts,
   setDevServerResolution,
   subscribeWantedDevServerPorts,
@@ -26,7 +37,17 @@ import {
 } from './agent-browser-ports';
 import type { DooredItem } from './wall-types';
 
-const REFRESH_MS = 5000;
+// Wait this long after interest changes before scanning, so a tab's open +
+// initial screencast settle first and quick navigation coalesces into one scan.
+const DEBOUNCE_MS = 600;
+// Re-scan cadence while a wanted port has no match yet (server may be starting).
+const PENDING_REFRESH_MS = 4000;
+// Re-scan cadence once every wanted port is matched (servers rarely move).
+const MATCHED_REFRESH_MS = 15000;
+// Upper bound on how long the idle scan may be deferred before it's forced.
+const IDLE_TIMEOUT_MS = 2000;
+
+type ResolveOutcome = 'busy' | 'empty' | 'pending' | 'matched';
 
 function isTerminalParams(params: unknown): boolean {
   if (!params || typeof params !== 'object') return true;
@@ -45,6 +66,21 @@ function servesLoopback(address: string): boolean {
   return address === '127.0.0.1' || address === '::1' || address === '0.0.0.0' || address === '::';
 }
 
+// requestIdleCallback isn't universal (absent in WKWebView / Tauri on macOS),
+// so fall back to a short timer. Handles are plain numbers in both paths.
+function scheduleIdle(cb: () => void): number {
+  if (typeof requestIdleCallback === 'function') {
+    return requestIdleCallback(cb, { timeout: IDLE_TIMEOUT_MS }) as unknown as number;
+  }
+  return setTimeout(cb, 1) as unknown as number;
+}
+
+function cancelIdle(handle: number | undefined): void {
+  if (handle == null) return;
+  if (typeof cancelIdleCallback === 'function') cancelIdleCallback(handle);
+  else clearTimeout(handle);
+}
+
 export function useDevServerPortCorrelation({
   apiRef,
   doorsRef,
@@ -55,7 +91,9 @@ export function useDevServerPortCorrelation({
   useEffect(() => {
     let cancelled = false;
     let running = false;
-    let timer: ReturnType<typeof setTimeout> | undefined;
+    let debounceTimer: ReturnType<typeof setTimeout> | undefined;
+    let refreshTimer: ReturnType<typeof setTimeout> | undefined;
+    let idleHandle: number | undefined;
 
     // Concise pane label (e.g. `pnpm dev`), mirroring buildDorSurfaces; falls
     // back to the panel/door title. Works for visible panes and minimized doors
@@ -72,15 +110,17 @@ export function useDevServerPortCorrelation({
       return fallbackTitle?.trim() || 'terminal';
     };
 
-    const resolveOnce = async () => {
-      if (cancelled || running) return;
+    const resolveOnce = async (): Promise<ResolveOutcome> => {
+      if (cancelled || running) return 'busy';
       const ports = getWantedDevServerPorts();
-      if (ports.length === 0) return;
+      if (ports.length === 0) return 'empty';
 
       const platform = getPlatform();
       if (!platform.getOpenPorts) {
+        // No port enumeration on this host (e.g. Tauri today): nothing will ever
+        // match, so settle to "no match" and pace as matched (no fast polling).
         for (const port of ports) setDevServerResolution(port, null);
-        return;
+        return 'matched';
       }
 
       running = true;
@@ -117,12 +157,11 @@ export function useDevServerPortCorrelation({
             owners.set(entry.port, list);
           }
         }));
-        if (cancelled) return;
+        if (cancelled) return 'busy';
 
         // Resolve only what's still wanted — interest can churn during the await.
-        const stillWanted = new Set(getWantedDevServerPorts());
-        for (const port of ports) {
-          if (!stillWanted.has(port)) continue;
+        const stillWanted = getWantedDevServerPorts();
+        for (const port of stillWanted) {
           const list = owners.get(port) ?? [];
           // Exactly one owner ⇒ confident match. Zero (no pane) or two+
           // (ambiguous) ⇒ no match; the header degrades to just the URL.
@@ -131,26 +170,54 @@ export function useDevServerPortCorrelation({
             : null;
           setDevServerResolution(port, match);
         }
+
+        if (stillWanted.length === 0) return 'empty';
+        // "pending" while any wanted port is still unmatched, so we keep looking
+        // (the server may not have started when the tab opened).
+        return stillWanted.every((port) => getDevServerResolution(port) != null) ? 'matched' : 'pending';
       } finally {
         running = false;
       }
     };
 
-    const tick = async () => {
-      await resolveOnce();
-      if (!cancelled) timer = setTimeout(() => void tick(), REFRESH_MS);
+    const scheduleRefresh = (delay: number) => {
+      if (cancelled) return;
+      if (refreshTimer) clearTimeout(refreshTimer);
+      refreshTimer = setTimeout(() => scheduleScan(0), delay);
     };
 
-    // New interest (a header just showed a loopback URL) resolves promptly
-    // rather than waiting out the slow refresh.
-    const unsubscribe = subscribeWantedDevServerPorts(() => {
-      if (!cancelled) void resolveOnce();
-    });
-    void tick();
+    // Run a scan during idle time, then pace the next one by the outcome.
+    const runIdleScan = () => {
+      idleHandle = scheduleIdle(() => {
+        idleHandle = undefined;
+        void resolveOnce().then((outcome) => {
+          if (cancelled || outcome === 'busy') return; // an in-flight scan paces itself
+          if (outcome === 'empty') return;             // nothing wanted → wait for new interest
+          scheduleRefresh(outcome === 'pending' ? PENDING_REFRESH_MS : MATCHED_REFRESH_MS);
+        });
+      });
+    };
+
+    // Coalesce triggers: debounce, then scan at idle. Never scans synchronously
+    // on the triggering event (tab open / navigation).
+    const scheduleScan = (delay: number) => {
+      if (cancelled) return;
+      if (debounceTimer) clearTimeout(debounceTimer);
+      cancelIdle(idleHandle);
+      idleHandle = undefined;
+      debounceTimer = setTimeout(runIdleScan, delay);
+    };
+
+    // A header showing a new loopback URL bumps "wanted"; debounce + defer so the
+    // scan lands after the tab is up, not during its first paints.
+    const unsubscribe = subscribeWantedDevServerPorts(() => scheduleScan(DEBOUNCE_MS));
+    scheduleScan(DEBOUNCE_MS);
 
     return () => {
       cancelled = true;
-      if (timer) clearTimeout(timer);
+      if (debounceTimer) clearTimeout(debounceTimer);
+      if (refreshTimer) clearTimeout(refreshTimer);
+      cancelIdle(idleHandle);
       unsubscribe();
     };
   }, [apiRef, doorsRef]);

--- a/lib/src/components/wall/use-dev-server-ports.ts
+++ b/lib/src/components/wall/use-dev-server-ports.ts
@@ -28,7 +28,7 @@ import { useEffect } from 'react';
 import type { DockviewApi } from 'dockview-react';
 import { getPlatform } from '../../lib/platform';
 import { getActivitySnapshot, getTerminalPaneStateSnapshot } from '../../lib/terminal-registry';
-import { buildAppTitleResolver, deriveHeader, resolveDisplayPrimary } from '../../lib/terminal-state';
+import { buildAppTitleResolver, deriveSurfaceLabel, DEFAULT_IDLE_TITLE } from '../../lib/terminal-state';
 import {
   getWantedDevServerPorts,
   setDevServerResolution,
@@ -105,9 +105,8 @@ export function useDevServerPortCorrelation({
       const state = states.get(id);
       if (state) {
         const appTitleForPane = buildAppTitleResolver(states, getActivitySnapshot());
-        const derived = deriveHeader(state, [state], { appTitleForPane });
-        const primary = resolveDisplayPrimary(derived.primary, fallbackTitle);
-        if (primary && primary !== '<idle>') return primary;
+        const primary = deriveSurfaceLabel(state, [state], appTitleForPane, fallbackTitle);
+        if (primary && primary !== DEFAULT_IDLE_TITLE) return primary;
       }
       return fallbackTitle?.trim() || 'terminal';
     };

--- a/lib/src/components/wall/use-dev-server-ports.ts
+++ b/lib/src/components/wall/use-dev-server-ports.ts
@@ -10,16 +10,17 @@
  *
  * This is **purely decorative and strictly off the hot path.** `getOpenPorts`
  * shells out (per-OS `lsof`/PowerShell) on the host that also drives the live
- * screencast, so a scan triggered the instant a tab opens would contend with
- * that tab's first screenshots. So resolution is:
+ * screencast, so scans must never pile onto tab-open or run on a timer forever:
  *   - **deferred & debounced** — a loopback URL appearing schedules a scan a
  *     beat later, coalescing rapid navigation, so tab-open finishes first;
  *   - **idle-scheduled** — the scan runs in `requestIdleCallback` time (with a
  *     timeout fallback), yielding to rendering and the screencast;
- *   - **adaptively paced** — it polls only while a loopback port is on screen,
- *     quickly while a port is still unmatched (a dev server may start after the
- *     tab), then backs off to a slow refresh once matched, and stops entirely
- *     when nothing is wanted.
+ *   - **scan once, then settle** — a matched port is remembered and never
+ *     rescanned; we only keep polling (slowly, at idle) while a wanted port is
+ *     still *unmatched* (a dev server may start after the tab opened);
+ *   - **re-validate on reload** — a surface reload (or navigating to a new
+ *     loopback port) un-settles and rescans, but optimistically: the current
+ *     chip stays until the rescan disagrees.
  * At most one scan is in flight (`running`), and `getOpenPorts`' own ~3s timeout
  * keeps a stuck pane from wedging the loop.
  */
@@ -29,11 +30,10 @@ import { getPlatform } from '../../lib/platform';
 import { getActivitySnapshot, getTerminalPaneStateSnapshot } from '../../lib/terminal-registry';
 import { buildAppTitleResolver, deriveHeader, resolveDisplayPrimary } from '../../lib/terminal-state';
 import {
-  getDevServerResolution,
   getWantedDevServerPorts,
   setDevServerResolution,
+  subscribeDevServerRescan,
   subscribeWantedDevServerPorts,
-  type DevServerMatch,
 } from './agent-browser-ports';
 import type { DooredItem } from './wall-types';
 
@@ -41,13 +41,12 @@ import type { DooredItem } from './wall-types';
 // initial screencast settle first and quick navigation coalesces into one scan.
 const DEBOUNCE_MS = 600;
 // Re-scan cadence while a wanted port has no match yet (server may be starting).
+// Once matched, a port is settled and not rescanned until reload/navigation.
 const PENDING_REFRESH_MS = 4000;
-// Re-scan cadence once every wanted port is matched (servers rarely move).
-const MATCHED_REFRESH_MS = 15000;
 // Upper bound on how long the idle scan may be deferred before it's forced.
 const IDLE_TIMEOUT_MS = 2000;
 
-type ResolveOutcome = 'busy' | 'empty' | 'pending' | 'matched';
+type ResolveOutcome = 'busy' | 'idle' | 'pending';
 
 function isTerminalParams(params: unknown): boolean {
   if (!params || typeof params !== 'object') return true;
@@ -94,6 +93,9 @@ export function useDevServerPortCorrelation({
     let debounceTimer: ReturnType<typeof setTimeout> | undefined;
     let refreshTimer: ReturnType<typeof setTimeout> | undefined;
     let idleHandle: number | undefined;
+    // Ports already matched to a pane. We don't rescan these until a reload
+    // (clears the whole set) or the port leaves "wanted" (navigation).
+    const settled = new Set<number>();
 
     // Concise pane label (e.g. `pnpm dev`), mirroring buildDorSurfaces; falls
     // back to the panel/door title. Works for visible panes and minimized doors
@@ -112,15 +114,24 @@ export function useDevServerPortCorrelation({
 
     const resolveOnce = async (): Promise<ResolveOutcome> => {
       if (cancelled || running) return 'busy';
-      const ports = getWantedDevServerPorts();
-      if (ports.length === 0) return 'empty';
+
+      const wanted = getWantedDevServerPorts();
+      // Drop settled ports that are no longer on screen (navigated away).
+      for (const port of [...settled]) {
+        if (!wanted.includes(port)) settled.delete(port);
+      }
+      if (wanted.length === 0) return 'idle';
+
+      // Only chase ports we haven't matched yet — matched ones stay put.
+      const unsettled = wanted.filter((port) => !settled.has(port));
+      if (unsettled.length === 0) return 'idle';
 
       const platform = getPlatform();
       if (!platform.getOpenPorts) {
         // No port enumeration on this host (e.g. Tauri today): nothing will ever
-        // match, so settle to "no match" and pace as matched (no fast polling).
-        for (const port of ports) setDevServerResolution(port, null);
-        return 'matched';
+        // match, so settle to "no match" and stop (don't poll).
+        for (const port of unsettled) setDevServerResolution(port, null);
+        return 'idle';
       }
 
       running = true;
@@ -159,22 +170,25 @@ export function useDevServerPortCorrelation({
         }));
         if (cancelled) return 'busy';
 
-        // Resolve only what's still wanted — interest can churn during the await.
-        const stillWanted = getWantedDevServerPorts();
-        for (const port of stillWanted) {
+        // Resolve only what's still wanted + unsettled — interest can churn
+        // during the await.
+        const stillWanted = new Set(getWantedDevServerPorts());
+        for (const port of unsettled) {
+          if (!stillWanted.has(port)) continue;
           const list = owners.get(port) ?? [];
-          // Exactly one owner ⇒ confident match. Zero (no pane) or two+
-          // (ambiguous) ⇒ no match; the header degrades to just the URL.
-          const match: DevServerMatch | null = list.length === 1
-            ? { paneId: list[0], label: labelForPane(list[0], titles.get(list[0]) ?? null) }
-            : null;
-          setDevServerResolution(port, match);
+          // Exactly one owner ⇒ confident match; settle it. Zero (no pane) or
+          // two+ (ambiguous) ⇒ no match; leave it unsettled so we keep looking
+          // (e.g. the dev server is still starting up).
+          if (list.length === 1) {
+            settled.add(port);
+            setDevServerResolution(port, { paneId: list[0], label: labelForPane(list[0], titles.get(list[0]) ?? null) });
+          } else {
+            setDevServerResolution(port, null);
+          }
         }
 
-        if (stillWanted.length === 0) return 'empty';
-        // "pending" while any wanted port is still unmatched, so we keep looking
-        // (the server may not have started when the tab opened).
-        return stillWanted.every((port) => getDevServerResolution(port) != null) ? 'matched' : 'pending';
+        const remaining = getWantedDevServerPorts().some((port) => !settled.has(port));
+        return remaining ? 'pending' : 'idle';
       } finally {
         running = false;
       }
@@ -186,20 +200,21 @@ export function useDevServerPortCorrelation({
       refreshTimer = setTimeout(() => scheduleScan(0), delay);
     };
 
-    // Run a scan during idle time, then pace the next one by the outcome.
+    // Run a scan during idle time; keep polling only while ports are unmatched.
     const runIdleScan = () => {
       idleHandle = scheduleIdle(() => {
         idleHandle = undefined;
         void resolveOnce().then((outcome) => {
-          if (cancelled || outcome === 'busy') return; // an in-flight scan paces itself
-          if (outcome === 'empty') return;             // nothing wanted → wait for new interest
-          scheduleRefresh(outcome === 'pending' ? PENDING_REFRESH_MS : MATCHED_REFRESH_MS);
+          if (cancelled) return;
+          // 'busy' → an in-flight scan paces itself; 'idle' → all matched (or
+          // nothing wanted) so stop until reload/navigation wakes us.
+          if (outcome === 'pending') scheduleRefresh(PENDING_REFRESH_MS);
         });
       });
     };
 
     // Coalesce triggers: debounce, then scan at idle. Never scans synchronously
-    // on the triggering event (tab open / navigation).
+    // on the triggering event (tab open / navigation / reload).
     const scheduleScan = (delay: number) => {
       if (cancelled) return;
       if (debounceTimer) clearTimeout(debounceTimer);
@@ -210,7 +225,13 @@ export function useDevServerPortCorrelation({
 
     // A header showing a new loopback URL bumps "wanted"; debounce + defer so the
     // scan lands after the tab is up, not during its first paints.
-    const unsubscribe = subscribeWantedDevServerPorts(() => scheduleScan(DEBOUNCE_MS));
+    const unsubscribeWanted = subscribeWantedDevServerPorts(() => scheduleScan(DEBOUNCE_MS));
+    // A reload un-settles every port and re-validates — optimistically, since we
+    // leave the published resolutions in place until the rescan overwrites them.
+    const unsubscribeRescan = subscribeDevServerRescan(() => {
+      settled.clear();
+      scheduleScan(DEBOUNCE_MS);
+    });
     scheduleScan(DEBOUNCE_MS);
 
     return () => {
@@ -218,7 +239,8 @@ export function useDevServerPortCorrelation({
       if (debounceTimer) clearTimeout(debounceTimer);
       if (refreshTimer) clearTimeout(refreshTimer);
       cancelIdle(idleHandle);
-      unsubscribe();
+      unsubscribeWanted();
+      unsubscribeRescan();
     };
   }, [apiRef, doorsRef]);
 }

--- a/lib/src/components/wall/use-dev-server-ports.ts
+++ b/lib/src/components/wall/use-dev-server-ports.ts
@@ -1,0 +1,157 @@
+/**
+ * Wall-side driver for the dev-server connection chip
+ * (docs/specs/dor-agent-browser.md → "Dev-server connection").
+ *
+ * A browser-surface header can't see other panes' open ports, so it registers
+ * the loopback port it's showing in the shared store (`useDevServerMatch`) and
+ * the Wall resolves it here: scan every terminal pane's listening ports
+ * (`getOpenPorts`), find the single pane serving that port, and publish back
+ * `{ paneId, label }`.
+ *
+ * Cost control (per the spec): only runs while at least one loopback port is
+ * wanted, resolves promptly when new interest appears, and otherwise refreshes
+ * on a slow interval. `getOpenPorts` has a ~3s timeout, so a stuck pane can't
+ * wedge the loop — `runningRef` keeps at most one sweep in flight.
+ */
+import { useEffect } from 'react';
+import type { DockviewApi } from 'dockview-react';
+import { getPlatform } from '../../lib/platform';
+import { getActivitySnapshot, getTerminalPaneStateSnapshot } from '../../lib/terminal-registry';
+import { buildAppTitleResolver, deriveHeader, resolveDisplayPrimary } from '../../lib/terminal-state';
+import {
+  getWantedDevServerPorts,
+  setDevServerResolution,
+  subscribeWantedDevServerPorts,
+  type DevServerMatch,
+} from './agent-browser-ports';
+import type { DooredItem } from './wall-types';
+
+const REFRESH_MS = 5000;
+
+function isTerminalParams(params: unknown): boolean {
+  if (!params || typeof params !== 'object') return true;
+  const surfaceType = (params as { surfaceType?: unknown }).surfaceType;
+  return surfaceType !== 'iframe' && surfaceType !== 'agent-browser';
+}
+
+function isTerminalDoor(door: DooredItem): boolean {
+  return (door.component ?? 'terminal') === 'terminal';
+}
+
+// A process bound here answers `localhost:<port>`: loopback (127.0.0.1 / ::1)
+// or any-interface (0.0.0.0 / ::). A process bound to one specific non-loopback
+// interface is excluded — it isn't reachable as localhost.
+function servesLoopback(address: string): boolean {
+  return address === '127.0.0.1' || address === '::1' || address === '0.0.0.0' || address === '::';
+}
+
+export function useDevServerPortCorrelation({
+  apiRef,
+  doorsRef,
+}: {
+  apiRef: React.MutableRefObject<DockviewApi | null>;
+  doorsRef: React.MutableRefObject<DooredItem[]>;
+}): void {
+  useEffect(() => {
+    let cancelled = false;
+    let running = false;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+
+    // Concise pane label (e.g. `pnpm dev`), mirroring buildDorSurfaces; falls
+    // back to the panel/door title. Works for visible panes and minimized doors
+    // alike (both keep their pty + terminal state).
+    const labelForPane = (id: string, fallbackTitle: string | null): string => {
+      const states = getTerminalPaneStateSnapshot();
+      const state = states.get(id);
+      if (state) {
+        const appTitleForPane = buildAppTitleResolver(states, getActivitySnapshot());
+        const derived = deriveHeader(state, [state], { appTitleForPane });
+        const primary = resolveDisplayPrimary(derived.primary, fallbackTitle);
+        if (primary && primary !== '<idle>') return primary;
+      }
+      return fallbackTitle?.trim() || 'terminal';
+    };
+
+    const resolveOnce = async () => {
+      if (cancelled || running) return;
+      const ports = getWantedDevServerPorts();
+      if (ports.length === 0) return;
+
+      const platform = getPlatform();
+      if (!platform.getOpenPorts) {
+        for (const port of ports) setDevServerResolution(port, null);
+        return;
+      }
+
+      running = true;
+      try {
+        const api = apiRef.current;
+        const doors = doorsRef.current;
+        // title lookups for labelling/fallback, keyed by surface id.
+        const titles = new Map<string, string | null>();
+        const candidates: string[] = [];
+        for (const panel of api?.panels ?? []) {
+          if (!isTerminalParams(panel.params)) continue;
+          candidates.push(panel.id);
+          titles.set(panel.id, panel.title ?? null);
+        }
+        for (const door of doors) {
+          if (!isTerminalDoor(door)) continue;
+          if (!candidates.includes(door.id)) candidates.push(door.id);
+          titles.set(door.id, door.title ?? null);
+        }
+
+        // port → the pane ids that listen on it (loopback-reachable binds only).
+        const owners = new Map<number, string[]>();
+        await Promise.all(candidates.map(async (id) => {
+          let open;
+          try {
+            open = await platform.getOpenPorts!(id);
+          } catch {
+            return;
+          }
+          for (const entry of open) {
+            if (entry.protocol !== 'tcp' || !servesLoopback(entry.address)) continue;
+            const list = owners.get(entry.port) ?? [];
+            if (!list.includes(id)) list.push(id);
+            owners.set(entry.port, list);
+          }
+        }));
+        if (cancelled) return;
+
+        // Resolve only what's still wanted — interest can churn during the await.
+        const stillWanted = new Set(getWantedDevServerPorts());
+        for (const port of ports) {
+          if (!stillWanted.has(port)) continue;
+          const list = owners.get(port) ?? [];
+          // Exactly one owner ⇒ confident match. Zero (no pane) or two+
+          // (ambiguous) ⇒ no match; the header degrades to just the URL.
+          const match: DevServerMatch | null = list.length === 1
+            ? { paneId: list[0], label: labelForPane(list[0], titles.get(list[0]) ?? null) }
+            : null;
+          setDevServerResolution(port, match);
+        }
+      } finally {
+        running = false;
+      }
+    };
+
+    const tick = async () => {
+      await resolveOnce();
+      if (!cancelled) timer = setTimeout(() => void tick(), REFRESH_MS);
+    };
+
+    // New interest (a header just showed a loopback URL) resolves promptly
+    // rather than waiting out the slow refresh.
+    const unsubscribe = subscribeWantedDevServerPorts(() => {
+      if (!cancelled) void resolveOnce();
+    });
+    void tick();
+
+    return () => {
+      cancelled = true;
+      if (timer) clearTimeout(timer);
+      unsubscribe();
+    };
+  }, [apiRef, doorsRef]);
+}

--- a/lib/src/components/wall/wall-context.tsx
+++ b/lib/src/components/wall/wall-context.tsx
@@ -32,6 +32,9 @@ export interface WallActions {
   onSplitV: (id: string | null, source?: 'keyboard' | 'mouse') => void;
   onZoom: (id: string) => void;
   onClickPanel: (id: string) => void;
+  /** Jump to/focus an arbitrary pane by id (visible or minimized). Used by the
+   *  browser header's dev-server chip to surface the terminal serving a port. */
+  onFocusPane: (id: string) => void;
   onStartRename: (id: string) => void;
   onFinishRename: (id: string, value: string) => SetTerminalUserTitleResult;
   onCancelRename: () => void;
@@ -46,6 +49,7 @@ export const WallActionsContext = createContext<WallActions>({
   onSplitV: () => {},
   onZoom: () => {},
   onClickPanel: () => {},
+  onFocusPane: () => {},
   onStartRename: () => {},
   onFinishRename: () => ({ accepted: true }),
   onCancelRename: () => {},

--- a/lib/src/lib/dom.test.ts
+++ b/lib/src/lib/dom.test.ts
@@ -1,0 +1,29 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, expect, it } from 'vitest';
+import { isEditableTarget } from './dom';
+
+describe('isEditableTarget', () => {
+  it('is true for input, textarea, and contentEditable elements', () => {
+    expect(isEditableTarget(document.createElement('input'))).toBe(true);
+    expect(isEditableTarget(document.createElement('textarea'))).toBe(true);
+    const editable = document.createElement('div');
+    // jsdom doesn't compute isContentEditable from the attribute, so set it.
+    Object.defineProperty(editable, 'isContentEditable', { value: true });
+    expect(isEditableTarget(editable)).toBe(true);
+  });
+
+  it('is false for non-text elements and null', () => {
+    expect(isEditableTarget(document.createElement('div'))).toBe(false);
+    expect(isEditableTarget(document.createElement('button'))).toBe(false);
+    expect(isEditableTarget(document.createElement('select'))).toBe(false);
+    expect(isEditableTarget(null)).toBe(false);
+  });
+
+  it('counts the xterm helper textarea — callers exclude it themselves', () => {
+    const helper = document.createElement('textarea');
+    helper.classList.add('xterm-helper-textarea');
+    expect(isEditableTarget(helper)).toBe(true);
+  });
+});

--- a/lib/src/lib/dom.ts
+++ b/lib/src/lib/dom.ts
@@ -1,0 +1,13 @@
+/** True when an event target / element is a real text input — an `<input>`,
+ *  `<textarea>`, or a contentEditable element. The shared predicate for "don't
+ *  hijack keystrokes (or focus) that belong to a form field."
+ *
+ *  Note: xterm's hidden `.xterm-helper-textarea` is a `<textarea>`, so it counts
+ *  here. That's right for code that treats it as the terminal's input (e.g.
+ *  blurring it to dismiss the mobile keyboard); callers that treat the terminal
+ *  itself as *non*-editable (e.g. mouse-selection chords) exclude that class
+ *  explicitly on top of this check. */
+export function isEditableTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false;
+  return target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable === true;
+}

--- a/lib/src/lib/platform/types.ts
+++ b/lib/src/lib/platform/types.ts
@@ -42,9 +42,10 @@ export interface AgentBrowserCommandResult {
 
 /** Subcommands the host will run on the webview's behalf — this is a narrow
  * channel for tab actions, screen-mode resizing (`set viewport` / `set
- * device`), HiDPI frame capture (`screenshot`), and session teardown, not a
- * general exec path. */
-export const AGENT_BROWSER_ALLOWED_SUBCOMMANDS = ['tab', 'set', 'screenshot', 'close'] as const;
+ * device`), HiDPI frame capture (`screenshot`), history navigation
+ * (`reload` / `back` / `forward`), and session teardown, not a general exec
+ * path. */
+export const AGENT_BROWSER_ALLOWED_SUBCOMMANDS = ['tab', 'set', 'screenshot', 'reload', 'back', 'forward', 'close'] as const;
 
 export interface AgentBrowserScreenshotResult {
   ok: boolean;

--- a/lib/src/lib/platform/types.ts
+++ b/lib/src/lib/platform/types.ts
@@ -42,10 +42,10 @@ export interface AgentBrowserCommandResult {
 
 /** Subcommands the host will run on the webview's behalf — this is a narrow
  * channel for tab actions, screen-mode resizing (`set viewport` / `set
- * device`), HiDPI frame capture (`screenshot`), history navigation
- * (`reload` / `back` / `forward`), and session teardown, not a general exec
+ * device`), HiDPI frame capture (`screenshot`), navigation (`open <url>`,
+ * `reload` / `back` / `forward`), and session teardown, not a general exec
  * path. */
-export const AGENT_BROWSER_ALLOWED_SUBCOMMANDS = ['tab', 'set', 'screenshot', 'reload', 'back', 'forward', 'close'] as const;
+export const AGENT_BROWSER_ALLOWED_SUBCOMMANDS = ['tab', 'set', 'screenshot', 'open', 'reload', 'back', 'forward', 'close'] as const;
 
 export interface AgentBrowserScreenshotResult {
   ok: boolean;

--- a/lib/src/lib/terminal-state.test.ts
+++ b/lib/src/lib/terminal-state.test.ts
@@ -9,6 +9,7 @@ import {
   COMMAND_FAIL_GLYPH,
   DEFAULT_IDLE_TITLE,
   deriveHeader,
+  deriveSurfaceLabel,
   buildAppTitleResolver,
   groupTerminalPanes,
   notificationDisplayTitle,
@@ -293,6 +294,16 @@ describe('header and grouping derivation', () => {
       primary: 'pnpm test --watch',
       secondary: 'api',
     });
+  });
+
+  it('deriveSurfaceLabel composes deriveHeader + resolveDisplayPrimary for one pane', () => {
+    // A real command label wins; the fallback title is ignored.
+    const running = runningPane('/repo/app', 'pnpm test --watch');
+    expect(deriveSurfaceLabel(running, [running], () => null, 'door title')).toBe('pnpm test --watch');
+    // An idle pane stays <idle> (resolveDisplayPrimary substitutes the fallback
+    // only for the generic command title, not for idle).
+    const idle = createTerminalPaneState();
+    expect(deriveSurfaceLabel(idle, [idle], () => null, 'door title')).toBe(DEFAULT_IDLE_TITLE);
   });
 
   it('lets fresh app-sent terminal titles override running command labels', () => {

--- a/lib/src/lib/terminal-state.ts
+++ b/lib/src/lib/terminal-state.ts
@@ -442,6 +442,20 @@ export function deriveHeader(
   return { primary: primary.text, secondary, lastCommandFailed: primary.failed || undefined };
 }
 
+/** A single surface's display label: the derived header primary, with the
+ *  saved/fallback title substituted when the primary is the generic command
+ *  title. The one place to compose `deriveHeader` + `resolveDisplayPrimary` for
+ *  one pane; callers that also need `secondary`/`lastCommandFailed` use
+ *  `deriveHeader` directly. */
+export function deriveSurfaceLabel(
+  pane: TerminalPaneState,
+  visiblePanes: TerminalPaneState[],
+  appTitleForPane: HeaderOptions['appTitleForPane'],
+  fallbackTitle: string | null | undefined,
+): string {
+  return resolveDisplayPrimary(deriveHeader(pane, visiblePanes, { appTitleForPane }).primary, fallbackTitle);
+}
+
 export function notificationDisplayTitle(
   notification: TerminalNotificationTitleLike | null | undefined,
 ): string | null {

--- a/lib/src/stories/AgentBrowserScreenModal.stories.tsx
+++ b/lib/src/stories/AgentBrowserScreenModal.stories.tsx
@@ -41,7 +41,6 @@ function useMockController(args: StoryArgs): ScreenController {
         displayUrl: 'localhost:5173',
         title: 'Vite + React',
         key: null,
-        connection: 'connected',
       }),
       chromeActions: {
         back: () => console.log('[story] back'),

--- a/lib/src/stories/AgentBrowserScreenModal.stories.tsx
+++ b/lib/src/stories/AgentBrowserScreenModal.stories.tsx
@@ -35,6 +35,19 @@ function useMockController(args: StoryArgs): ScreenController {
       id: 'story',
       subscribe: () => () => {},
       snapshot: () => snapshot,
+      subscribeChrome: () => () => {},
+      chrome: () => ({
+        url: 'http://localhost:5173/',
+        displayUrl: 'localhost:5173',
+        title: 'Vite + React',
+        key: null,
+        connection: 'connected',
+      }),
+      chromeActions: {
+        back: () => console.log('[story] back'),
+        forward: () => console.log('[story] forward'),
+        reload: () => console.log('[story] reload'),
+      },
       hostCapable: args.hostCapable,
       actions: {
         engageSync: () => console.log('[story] engageSync'),

--- a/lib/src/stories/AgentBrowserScreenModal.stories.tsx
+++ b/lib/src/stories/AgentBrowserScreenModal.stories.tsx
@@ -43,6 +43,7 @@ function useMockController(args: StoryArgs): ScreenController {
         key: null,
       }),
       chromeActions: {
+        navigate: (url) => console.log('[story] navigate', url),
         back: () => console.log('[story] back'),
         forward: () => console.log('[story] forward'),
         reload: () => console.log('[story] reload'),

--- a/lib/src/stories/BrowserChromeHeader.stories.tsx
+++ b/lib/src/stories/BrowserChromeHeader.stories.tsx
@@ -11,7 +11,6 @@ import {
 import { SurfacePaneHeader } from '../components/wall/SurfacePaneHeader';
 import {
   registerAgentBrowserScreen,
-  type ChromeConnection,
   type ChromeSnapshot,
   type ScreenRegistration,
   type ScreenSnapshot,
@@ -25,8 +24,8 @@ import { setDevServerResolution } from '../components/wall/agent-browser-ports';
  * (docs/specs/dor-agent-browser.md → "Browser-Chrome Header").
  *
  * `SurfacePaneHeader` decides "this is a browser surface" purely from the
- * presence of a screen controller for its `api.id`, and reads URL / key /
- * connection from that controller's chrome snapshot. So the story registers a
+ * presence of a screen controller for its `api.id`, and reads URL / key from
+ * that controller's chrome snapshot. So the story registers a
  * controller backed by the args and pushes updates as the controls change —
  * exactly the real body→header path, just driven by knobs instead of a live
  * stream. The dev-server chip is wired through the genuine port store.
@@ -57,7 +56,6 @@ interface StoryArgs {
   htmlTitle: string;
   /** Managed --key; '' = raw --session (no badge), 'default' is skipped. */
   paneKey: string;
-  connection: ChromeConnection;
   /** Pane label for the dev-server chip; '' = no pane correlates (chip hidden). */
   devServerLabel: string;
   /** Whether the host can run agent-browser commands (false ⇒ nav/resize inert). */
@@ -87,8 +85,7 @@ function BrowserChromeStory(args: StoryArgs) {
     displayUrl: hostPathDisplay(args.url),
     title: args.htmlTitle || null,
     key: args.paneKey || null,
-    connection: args.connection,
-  }), [args.url, args.htmlTitle, args.paneKey, args.connection]);
+  }), [args.url, args.htmlTitle, args.paneKey]);
 
   // Register on mount; re-register when hostCapable flips (it's fixed at
   // registration time). The update effects below keep the snapshots live.
@@ -164,7 +161,6 @@ const meta: Meta<typeof BrowserChromeStory> = {
     url: { control: 'text' },
     htmlTitle: { control: 'text' },
     paneKey: { control: 'select', options: ['', 'default', 'storybook'] },
-    connection: { control: 'radio', options: ['connected', 'connecting', 'lost'] },
     devServerLabel: { control: 'text' },
     hostCapable: { control: 'boolean' },
     width: { control: { type: 'range', min: 200, max: 900, step: 10 } },
@@ -175,7 +171,6 @@ const meta: Meta<typeof BrowserChromeStory> = {
     url: 'http://localhost:5173/app',
     htmlTitle: 'Vite + React',
     paneKey: 'storybook',
-    connection: 'connected',
     devServerLabel: 'pnpm dev',
     hostCapable: true,
     width: 620,
@@ -202,11 +197,6 @@ export const RawSession: Story = {
 /** The differentiated piece: a localhost URL correlated to a terminal pane. */
 export const DevServerConnected: Story = {
   args: { url: 'http://localhost:6006/', devServerLabel: 'storybook', paneKey: 'storybook' },
-};
-
-/** Session stream dropped — connection is lost. */
-export const ConnectionLost: Story = {
-  args: { connection: 'lost' },
 };
 
 /** Narrow header: split/zoom collapse first (≤420px), then nav (≤360px). */

--- a/lib/src/stories/BrowserChromeHeader.stories.tsx
+++ b/lib/src/stories/BrowserChromeHeader.stories.tsx
@@ -7,7 +7,7 @@ import {
   WindowFocusedContext,
   ZoomedContext,
   type WallActions,
-} from '../components/Wall';
+} from '../components/wall/wall-context';
 import { SurfacePaneHeader } from '../components/wall/SurfacePaneHeader';
 import {
   registerAgentBrowserScreen,

--- a/lib/src/stories/BrowserChromeHeader.stories.tsx
+++ b/lib/src/stories/BrowserChromeHeader.stories.tsx
@@ -1,0 +1,215 @@
+import { useEffect, useId, useMemo, useRef } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import {
+  ModeContext,
+  SelectedIdContext,
+  WallActionsContext,
+  WindowFocusedContext,
+  ZoomedContext,
+  type WallActions,
+} from '../components/Wall';
+import { SurfacePaneHeader } from '../components/wall/SurfacePaneHeader';
+import {
+  registerAgentBrowserScreen,
+  type ChromeConnection,
+  type ChromeSnapshot,
+  type ScreenRegistration,
+  type ScreenSnapshot,
+  type ScreenState,
+} from '../components/wall/agent-browser-screen';
+import { hostPathDisplay, loopbackPort } from '../components/wall/browser-url';
+import { setDevServerResolution } from '../components/wall/agent-browser-ports';
+
+/**
+ * Playground for the agent-browser surface's browser-chrome header
+ * (docs/specs/dor-agent-browser.md → "Browser-Chrome Header").
+ *
+ * `SurfacePaneHeader` decides "this is a browser surface" purely from the
+ * presence of a screen controller for its `api.id`, and reads URL / key /
+ * connection from that controller's chrome snapshot. So the story registers a
+ * controller backed by the args and pushes updates as the controls change —
+ * exactly the real body→header path, just driven by knobs instead of a live
+ * stream. The dev-server chip is wired through the genuine port store.
+ */
+
+// Actions log to the console so nav / focus clicks are observable in the story.
+const loggingActions: WallActions = {
+  onKill: () => console.log('[story] kill'),
+  onMinimize: () => console.log('[story] minimize'),
+  onAlertButton: () => 'noop',
+  onToggleTodo: () => {},
+  onSplitH: () => console.log('[story] split left/right'),
+  onSplitV: () => console.log('[story] split top/bottom'),
+  onZoom: () => console.log('[story] zoom'),
+  onClickPanel: () => console.log('[story] click panel'),
+  onFocusPane: (id) => console.log('[story] focus pane', id),
+  onStartRename: () => {},
+  onFinishRename: () => ({ accepted: true }),
+  onCancelRename: () => {},
+};
+
+interface StoryArgs {
+  /** Drives the SYNCED/SCALED chip + the modal it opens. */
+  state: ScreenState;
+  /** Active tab URL — also the source of the host+path text and loopback port. */
+  url: string;
+  /** Active tab HTML <title> (shown as the URL's tooltip). */
+  htmlTitle: string;
+  /** Managed --key; '' = raw --session (no badge), 'default' is skipped. */
+  paneKey: string;
+  connection: ChromeConnection;
+  /** Pane label for the dev-server chip; '' = no pane correlates (chip hidden). */
+  devServerLabel: string;
+  /** Whether the host can run agent-browser commands (false ⇒ nav/resize inert). */
+  hostCapable: boolean;
+  /** Header width — shrink past 420/360 to watch split-zoom then nav collapse. */
+  width: number;
+  /** Whether the surface is the selected/active pane (header highlight). */
+  selected: boolean;
+}
+
+function BrowserChromeStory(args: StoryArgs) {
+  // Unique per story instance so autodocs (which mounts several at once) don't
+  // collide on one registry id.
+  const surfaceId = useId();
+  const registrationRef = useRef<ScreenRegistration | null>(null);
+
+  const screenSnapshot: ScreenSnapshot = useMemo(() => ({
+    state: args.state,
+    viewport: { w: 1280, h: 720, dpr: 1 },
+    paneCss: args.state === 'SYNCED' ? { w: 1280, h: 720 } : { w: 980, h: 560 },
+    displayDpr: 2,
+    syncEngaged: args.state === 'SYNCED',
+  }), [args.state]);
+
+  const chromeSnapshot: ChromeSnapshot = useMemo(() => ({
+    url: args.url,
+    displayUrl: hostPathDisplay(args.url),
+    title: args.htmlTitle || null,
+    key: args.paneKey || null,
+    connection: args.connection,
+  }), [args.url, args.htmlTitle, args.paneKey, args.connection]);
+
+  // Register on mount; re-register when hostCapable flips (it's fixed at
+  // registration time). The update effects below keep the snapshots live.
+  useEffect(() => {
+    const registration = registerAgentBrowserScreen(surfaceId, {
+      snapshot: screenSnapshot,
+      chrome: chromeSnapshot,
+      actions: {
+        engageSync: () => console.log('[story] engageSync'),
+        applyDevice: (name) => console.log('[story] applyDevice', name),
+        applyViewport: (w, h, dpr) => console.log('[story] applyViewport', w, h, dpr),
+        openModal: () => console.log('[story] openModal'),
+      },
+      chromeActions: {
+        back: () => console.log('[story] back'),
+        forward: () => console.log('[story] forward'),
+        reload: () => console.log('[story] reload'),
+      },
+      hostCapable: args.hostCapable,
+    });
+    registrationRef.current = registration;
+    return () => {
+      registration.dispose();
+      registrationRef.current = null;
+    };
+    // Re-register only when the surface id or host capability changes; the live
+    // snapshots are kept current by the two update effects below.
+  }, [surfaceId, args.hostCapable]);
+
+  useEffect(() => {
+    registrationRef.current?.update(screenSnapshot);
+  }, [screenSnapshot]);
+
+  useEffect(() => {
+    registrationRef.current?.updateChrome(chromeSnapshot);
+  }, [chromeSnapshot]);
+
+  // Stand in for the Wall's port→pane correlation: when the URL is loopback,
+  // publish (or clear) a match for its port so the chip renders.
+  const port = loopbackPort(args.url);
+  useEffect(() => {
+    if (port == null) return;
+    const label = args.devServerLabel.trim();
+    setDevServerResolution(port, label ? { paneId: 'term-dev', label } : null);
+  }, [port, args.devServerLabel]);
+
+  const mockApi = { id: surfaceId, title: args.htmlTitle || hostPathDisplay(args.url) } as never;
+
+  return (
+    <ModeContext.Provider value="passthrough">
+      <SelectedIdContext.Provider value={args.selected ? surfaceId : null}>
+        <WindowFocusedContext.Provider value={true}>
+          <ZoomedContext.Provider value={false}>
+            <WallActionsContext.Provider value={loggingActions}>
+              <div style={{ width: args.width }}>
+                <div className="bg-app-bg" style={{ height: 26 }}>
+                  <SurfacePaneHeader api={mockApi} containerApi={{} as never} params={{}} tabLocation={'header' as never} />
+                </div>
+              </div>
+            </WallActionsContext.Provider>
+          </ZoomedContext.Provider>
+        </WindowFocusedContext.Provider>
+      </SelectedIdContext.Provider>
+    </ModeContext.Provider>
+  );
+}
+
+const meta: Meta<typeof BrowserChromeStory> = {
+  title: 'Components/BrowserChromeHeader',
+  component: BrowserChromeStory,
+  argTypes: {
+    state: { control: 'radio', options: ['SYNCED', 'SCALED'] },
+    url: { control: 'text' },
+    htmlTitle: { control: 'text' },
+    paneKey: { control: 'select', options: ['', 'default', 'storybook'] },
+    connection: { control: 'radio', options: ['connected', 'connecting', 'lost'] },
+    devServerLabel: { control: 'text' },
+    hostCapable: { control: 'boolean' },
+    width: { control: { type: 'range', min: 200, max: 900, step: 10 } },
+    selected: { control: 'boolean' },
+  },
+  args: {
+    state: 'SYNCED',
+    url: 'http://localhost:5173/app',
+    htmlTitle: 'Vite + React',
+    paneKey: 'storybook',
+    connection: 'connected',
+    devServerLabel: 'pnpm dev',
+    hostCapable: true,
+    width: 620,
+    selected: true,
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof BrowserChromeStory>;
+
+/** Everything on at once: key badge + URL + dev-server chip + nav. */
+export const Playground: Story = {};
+
+/** Letterboxed viewport — the chip reads SCALED (click it for the modal). */
+export const Scaled: Story = {
+  args: { state: 'SCALED' },
+};
+
+/** No --key badge, no dev-server match — the bare host+path case. */
+export const RawSession: Story = {
+  args: { paneKey: '', devServerLabel: '', url: 'https://example.com/docs' },
+};
+
+/** The differentiated piece: a localhost URL correlated to a terminal pane. */
+export const DevServerConnected: Story = {
+  args: { url: 'http://localhost:6006/', devServerLabel: 'storybook', paneKey: 'storybook' },
+};
+
+/** Session stream dropped — connection is lost. */
+export const ConnectionLost: Story = {
+  args: { connection: 'lost' },
+};
+
+/** Narrow header: split/zoom collapse first (≤420px), then nav (≤360px). */
+export const Narrow: Story = {
+  args: { width: 340 },
+};

--- a/lib/src/stories/BrowserChromeHeader.stories.tsx
+++ b/lib/src/stories/BrowserChromeHeader.stories.tsx
@@ -100,6 +100,7 @@ function BrowserChromeStory(args: StoryArgs) {
         openModal: () => console.log('[story] openModal'),
       },
       chromeActions: {
+        navigate: (url) => console.log('[story] navigate', url),
         back: () => console.log('[story] back'),
         forward: () => console.log('[story] forward'),
         reload: () => console.log('[story] reload'),

--- a/lib/src/stories/MouseHeaderIcon.stories.tsx
+++ b/lib/src/stories/MouseHeaderIcon.stories.tsx
@@ -28,6 +28,7 @@ const noopActions: WallActions = {
   onSplitV: () => {},
   onZoom: () => {},
   onClickPanel: () => {},
+  onFocusPane: () => {},
   onStartRename: () => {},
   onFinishRename: () => ({ accepted: true }),
   onCancelRename: () => {},

--- a/lib/src/stories/ShellCwd.stories.tsx
+++ b/lib/src/stories/ShellCwd.stories.tsx
@@ -48,6 +48,7 @@ const noopActions: WallActions = {
   onSplitV: () => {},
   onZoom: () => {},
   onClickPanel: () => {},
+  onFocusPane: () => {},
   onStartRename: () => {},
   onFinishRename: () => ({ accepted: true }),
   onCancelRename: () => {},

--- a/lib/src/stories/TerminalPaneHeader.stories.tsx
+++ b/lib/src/stories/TerminalPaneHeader.stories.tsx
@@ -22,6 +22,7 @@ const noopActions: WallActions = {
   onSplitV: () => {},
   onZoom: () => {},
   onClickPanel: () => {},
+  onFocusPane: () => {},
   onStartRename: () => {},
   onFinishRename: () => ({ accepted: true }),
   onCancelRename: () => {},


### PR DESCRIPTION
Reshapes the `dor agent-browser` surface header to read like a real browser, and adds the one thing only Dormouse can show: which terminal pane in the workspace is serving the localhost URL you're looking at. Builds on the agent-browser surface from #140.

## What's new

- **Browser-chrome header layout** (`SurfacePaneHeader.tsx`) — left→right like Chrome: SYNCED/SCALED chip · back/forward/reload · a quiet inline `--key` label (non-default keys only) · the URL · the dev-server link. Width-responsive; terminals/iframes untouched.
- **URL over HTML title** — the active tab's URL is the primary text (HTML `<title>` → tooltip). When a dev-server link fronts it, the URL collapses to just the path (the domain is redundant with the chip).
- **Click-to-navigate** — clicking the URL opens an inline editor (the terminal-rename pattern), pre-filled + all-selected. Enter navigates (`open <url>`, scheme-normalized — `http://` for loopback so a bare `localhost:5173` doesn't SSL-error); Escape/blur cancels, omnibox-style.
- **Back / forward / reload** — native agent-browser commands, always-enabled.
- **Dev-server connection chip (the differentiated piece)** — when the active tab is loopback, correlate `<port>` to the terminal pane serving it (via `getOpenPorts`, its first UI consumer) and surface `pnpm dev :5173`; click focuses that terminal. Resolution is strictly off the hot path: debounced + idle-scheduled (never competes with the tab's first screencast frames), scans once then settles, and re-validates only on reload.

## Notable internals

- A second **chrome snapshot** channel on the per-surface controller (URL/key), separate from the screen snapshot so tab updates don't churn the SYNCED/SCALED chip.
- A Wall-side port→pane correlation store + `onFocusPane` action (visible pane → focus, minimized door → reattach).
- Editable-target guard added to the panel's key-forwarder so header inputs keep their keystrokes.

## Storybook

New **Components/BrowserChromeHeader** playground (every piece driven by controls); fixed a pre-existing `dor/*` resolution gap in Storybook's Vite config that broke all Wall-importing stories.

## DRY / cleanup

A `/simplify` pass plus cross-codebase dedup: shared `isEditableTarget` (3 drifted copies), `deriveSurfaceLabel` (the `deriveHeader`+`resolveDisplayPrimary` triple across Baseboard/Wall/dev-server), and `hostPathDisplay(url, includeSearch)` replacing Wall's duplicate `iframeTitle`.

## Spec & tests

`docs/specs/dor-agent-browser.md` updated throughout. Full suite green (592 tests), typecheck clean; verified live in `dor ab` against a running Storybook. Also carries the `docs: split the iframe surface into its own spec` commit the agent-browser spec links to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)