### PR TITLE
TerminalPaneHeader: keep minimize/close visible as the header narrows

### DIFF
--- a/lib/src/components/wall/TerminalPaneHeader.tsx
+++ b/lib/src/components/wall/TerminalPaneHeader.tsx
@@ -209,7 +209,7 @@ export function TerminalPaneHeader({ api }: IDockviewPanelHeaderProps) {
       className={tabVariant({ state: isActiveHeader ? 'active' : 'inactive' })}
       onMouseDown={() => actions.onClickPanel(api.id)}
     >
-      <div className="flex flex-1 min-w-0 items-center gap-1.5">
+      <div className="flex flex-1 min-w-0 items-center gap-1.5 overflow-hidden">
         {isRenaming ? (
           <input
             data-renaming-input-for={api.id}
@@ -315,7 +315,7 @@ export function TerminalPaneHeader({ api }: IDockviewPanelHeaderProps) {
       </div>
       {!isRenaming && (
         <>
-          {showMouseIcon && (
+          {showMouseIcon && tier !== 'minimal' && (
             <div className="ml-1 shrink-0">
               <HeaderActionButton
                 className="flex h-5 min-w-5 items-center justify-center rounded transition-colors shrink-0 hover:bg-current/10"
@@ -359,6 +359,14 @@ export function TerminalPaneHeader({ api }: IDockviewPanelHeaderProps) {
               >{zoomed ? <ArrowsInIcon size={14} /> : <ArrowsOutIcon size={14} />}</HeaderActionButton>
             </div>
           )}
+          {/*
+            Minimize + close are the highest-priority controls: they must stay
+            visible no matter how narrow the header gets. They sit last (so
+            nothing fixed-width is to their right to push them off) and every
+            other element yields first — the title/bell region clips via
+            `overflow-hidden`, split/zoom drop below the `full` tier, and the
+            mouse icon drops at the `minimal` tier.
+          */}
           <div className="ml-1 flex shrink-0 items-center gap-0.5">
             <HeaderActionButton
               className="flex h-5 min-w-5 items-center justify-center rounded transition-colors hover:bg-current/10"

--- a/lib/src/stories/TerminalPaneHeader.stories.tsx
+++ b/lib/src/stories/TerminalPaneHeader.stories.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
 import {
   TerminalPaneHeader,
@@ -10,6 +11,7 @@ import {
 } from '../components/Wall';
 import type { ActivityNotification } from '../lib/alert-manager';
 import type { SetTerminalUserTitleResult } from '../lib/terminal-registry';
+import { removeMouseSelectionState, setMouseReporting, setOverride } from '../lib/mouse-selection';
 
 const SESSION_ID = 'tab-story';
 
@@ -58,6 +60,7 @@ function TabStory({
   isRenaming = false,
   width = 360,
   reducedMotion = false,
+  mouseCaptured = false,
   actions = noopActions,
 }: {
   title?: string;
@@ -66,9 +69,18 @@ function TabStory({
   isRenaming?: boolean;
   width?: number;
   reducedMotion?: boolean;
+  /** Simulate a TUI capturing the mouse, which surfaces the mouse-override icon. */
+  mouseCaptured?: boolean;
   actions?: WallActions;
 }) {
   const mockApi = { id: SESSION_ID, title } as any;
+
+  useEffect(() => {
+    if (!mouseCaptured) return;
+    setMouseReporting(SESSION_ID, 'any');
+    setOverride(SESSION_ID, 'temporary');
+    return () => removeMouseSelectionState(SESSION_ID);
+  }, [mouseCaptured]);
 
   return (
     <ModeContext.Provider value={mode}>
@@ -132,6 +144,51 @@ async function submitReservedRename() {
   await wait(50);
 }
 
+/**
+ * Confirms the minimize + close controls are the top-priority elements of the
+ * header: they must render and stay fully inside the header bounds (never
+ * clipped or pushed out) no matter how narrow it gets. Throws — so the failure
+ * surfaces in Storybook's Interactions panel — if either control is missing,
+ * collapsed to zero size, or sticking outside the header's horizontal extent.
+ */
+async function assertControlsVisible({ canvasElement }: { canvasElement: HTMLElement }) {
+  const CONTROLS = [
+    ['Minimize', '[aria-label="Minimize"]'],
+    ['Kill', '[aria-label="Kill"]'],
+  ] as const;
+  const EPS = 0.5;
+
+  // Returns a human-readable reason the controls aren't fully visible yet, or
+  // null once every control is rendered and sits inside the header bounds.
+  const violation = (): string | null => {
+    const header = canvasElement.querySelector<HTMLElement>('.bg-app-bg');
+    if (!header) return 'header container not found';
+    const bounds = header.getBoundingClientRect();
+    for (const [name, selector] of CONTROLS) {
+      const el = canvasElement.querySelector<HTMLElement>(selector);
+      if (!el) return `${name} button is not rendered`;
+      const r = el.getBoundingClientRect();
+      if (r.width <= 0 || r.height <= 0) return `${name} button collapsed to zero size (hidden)`;
+      if (r.left < bounds.left - EPS || r.right > bounds.right + EPS) {
+        return `${name} button is clipped: button x=[${r.left.toFixed(1)}, ${r.right.toFixed(1)}] `
+          + `exceeds header x=[${bounds.left.toFixed(1)}, ${bounds.right.toFixed(1)}]`;
+      }
+    }
+    return null;
+  };
+
+  // Poll until the primed state (two rAFs) and the ResizeObserver-driven tier
+  // have settled, instead of guessing a fixed delay. Surface the last reason if
+  // it never settles within the timeout.
+  const start = performance.now();
+  let reason = violation();
+  while (reason && performance.now() - start < 1000) {
+    await wait(16);
+    reason = violation();
+  }
+  if (reason) throw new Error(reason);
+}
+
 const NOTIFICATIONS = {
   osc9BodyOnly: {
     source: 'OSC 9',
@@ -175,6 +232,7 @@ const meta: Meta<typeof TabStory> = {
     title: { control: 'text' },
     width: { control: 'number' },
     reducedMotion: { control: 'boolean' },
+    mouseCaptured: { control: 'boolean' },
   },
   args: {
     title: 'build-server',
@@ -183,6 +241,7 @@ const meta: Meta<typeof TabStory> = {
     isRenaming: false,
     width: 360,
     reducedMotion: false,
+    mouseCaptured: false,
   },
 };
 
@@ -370,4 +429,57 @@ export const RenameRejectedReserved: Story = {
     todo: false,
   }),
   play: submitReservedRename,
+};
+
+// --- Minimize + close stay visible as the header shrinks -------------------
+//
+// These stories drive the header down to (and below) the `minimal` tier and
+// assert in their play function that the minimize and close controls remain
+// rendered and fully inside the header bounds. The assertion uses live layout
+// geometry, so it confirms the controls in the real Storybook browser.
+
+export const NarrowControlsVisible: Story = {
+  args: {
+    width: 110,
+  },
+  parameters: primedState({
+    status: 'NOTHING_TO_SHOW',
+    todo: false,
+  }),
+  play: assertControlsVisible,
+};
+
+export const ExtremelyNarrowControlsVisible: Story = {
+  args: {
+    width: 76,
+  },
+  parameters: primedState({
+    status: 'ALERT_RINGING',
+    todo: true,
+  }),
+  play: assertControlsVisible,
+};
+
+export const NarrowWithMouseCaptureControlsVisible: Story = {
+  args: {
+    width: 120,
+    mouseCaptured: true,
+  },
+  parameters: primedState({
+    status: 'NOTHING_TO_SHOW',
+    todo: false,
+  }),
+  play: assertControlsVisible,
+};
+
+export const NarrowLongTitleControlsVisible: Story = {
+  args: {
+    title: 'my-extremely-long-running-background-process-with-a-very-descriptive-name',
+    width: 130,
+  },
+  parameters: primedState({
+    status: 'ALERT_RINGING',
+    todo: true,
+  }),
+  play: assertControlsVisible,
 };


### PR DESCRIPTION
## What

Make the **minimize** and **close** controls the highest-priority elements of the terminal pane header, so they stay visible no matter how narrow the header gets.

### The problem

The header is a flex row: `[title + bell + todo (flex-1)] [mouse icon] [split/zoom] [minimize + close]`. Two things meant the controls were *not* actually the last to go when space ran out:

1. The leading title/bell region had `min-w-0` but **no `overflow-hidden`**, so the fixed-width bell could overflow and overlap the controls.
2. The mouse-override icon was a fixed `shrink-0` sibling sitting **to the left** of minimize/close. Because a flex row clips from its right edge, the rightmost group (minimize/close) was the *first* to be pushed off — backwards from the requirement.

### The fix (`lib/src/components/wall/TerminalPaneHeader.tsx`)

- Add `overflow-hidden` to the leading title/bell region so it clips cleanly instead of overflowing onto the controls.
- Hide the mouse-override icon at the `minimal` tier, consistent with how split/zoom drop below the `full` tier and the TODO pill drops at `minimal`.

Net effect: every other element yields before the controls, which now stay fully visible down to the physical floor (~65px — just the two buttons + padding).

### Stories (`lib/src/stories/TerminalPaneHeader.stories.tsx`)

Added a self-verifying `assertControlsVisible` play function that reads live layout geometry and **throws** (surfacing in Storybook's Interactions panel) if either control is missing, zero-size, or clipped outside the header bounds. It polls until the primed state + ResizeObserver-driven tier settle, rather than using a fixed delay. Four new stories exercise it:

- `NarrowControlsVisible` (110px)
- `ExtremelyNarrowControlsVisible` (76px, alert ringing + todo)
- `NarrowWithMouseCaptureControlsVisible` (120px, simulated TUI mouse capture)
- `NarrowLongTitleControlsVisible` (130px, very long title + alert ringing)

A `mouseCaptured` story arg was added to surface the mouse-override icon.

## Testing

- `tsc -b` passes.
- All 620 existing lib unit tests pass.
- Story assertions verify behavior in the real Storybook browser (`pnpm --filter dormouse-lib storybook`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)