### PR TITLE
ci: enable Renovate dependency dashboard

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "enabledManagers": ["github-actions", "npm", "cargo"],
+  "dependencyDashboard": true,
   "timezone": "America/Los_Angeles",
   "schedule": ["* * * * 1"],
   "packageRules": [


### PR DESCRIPTION
The repo's renovate.json has no `extends`, so it never picked up the dependency dashboard that config:recommended would normally enable, and Renovate was actively closing it ("Closing Dependency Dashboard" in the job log). Enable it explicitly so the dashboard issue lists pending update groups and exposes per-update checkboxes to create PRs on demand (e.g. outside the Monday-only schedule).