### PR TITLE
cleanup: rename leftover mouseterm identifiers to dormouse

### DIFF
--- a/lib/src/lib/platform/vscode-adapter.ts
+++ b/lib/src/lib/platform/vscode-adapter.ts
@@ -13,7 +13,7 @@ import type { VSCodeWorkbenchCommand } from '../vscode-keybindings';
 
 export class VSCodeAdapter implements PlatformAdapter {
   private vscode: ReturnType<typeof acquireVsCodeApi>;
-  private hostState: unknown = (globalThis as typeof globalThis & { __MOUSETERM_HOST_STATE__?: unknown }).__MOUSETERM_HOST_STATE__ ?? null;
+  private hostState: unknown = (globalThis as typeof globalThis & { __DORMOUSE_HOST_STATE__?: unknown }).__DORMOUSE_HOST_STATE__ ?? null;
   private dataHandlers = new Set<(detail: { id: string; data: string }) => void>();
   private exitHandlers = new Set<(detail: { id: string; exitCode: number }) => void>();
   private listHandlers = new Set<(detail: { ptys: PtyInfo[] }) => void>();
@@ -38,8 +38,8 @@ export class VSCodeAdapter implements PlatformAdapter {
     // the first terminal on startup (which spawns synchronously on Wall
     // mount) picks up the selected shell, not the platform default.
     const injectedShell = (globalThis as typeof globalThis & {
-      __MOUSETERM_SELECTED_SHELL__?: { shell?: string; args?: string[] } | null;
-    }).__MOUSETERM_SELECTED_SHELL__;
+      __DORMOUSE_SELECTED_SHELL__?: { shell?: string; args?: string[] } | null;
+    }).__DORMOUSE_SELECTED_SHELL__;
     if (injectedShell?.shell) {
       setDefaultShellOpts({ shell: injectedShell.shell, args: injectedShell.args });
     }

--- a/lib/src/lib/terminal-prompt-shape.test.ts
+++ b/lib/src/lib/terminal-prompt-shape.test.ts
@@ -3,7 +3,7 @@ import { derivePromptShape, extractCommand } from './terminal-prompt-shape';
 
 describe('derivePromptShape', () => {
   it('reads the zsh terminator and ignores earlier non-alphanumerics', () => {
-    expect(derivePromptShape('ntwigg@ntwigg-mac-2025 mouseterm % ')).toEqual({ terminator: '%', countBefore: 0 });
+    expect(derivePromptShape('ntwigg@ntwigg-mac-2025 dormouse % ')).toEqual({ terminator: '%', countBefore: 0 });
   });
 
   it('reads the cmd.exe terminator as ">" regardless of the path', () => {
@@ -32,7 +32,7 @@ describe('extractCommand', () => {
   const zsh = { terminator: '%', countBefore: 0 };
 
   it('slices the command after the zsh terminator and its space', () => {
-    expect(extractCommand('ntwigg@ntwigg-mac-2025 mouseterm % pnpm dev:website', zsh)).toBe('pnpm dev:website');
+    expect(extractCommand('ntwigg@ntwigg-mac-2025 dormouse % pnpm dev:website', zsh)).toBe('pnpm dev:website');
   });
 
   it('slices the command with no space after the cmd.exe terminator', () => {
@@ -49,7 +49,7 @@ describe('extractCommand', () => {
   });
 
   it('returns null for a bare prompt with nothing typed', () => {
-    expect(extractCommand('ntwigg@mac mouseterm % ', zsh)).toBeNull();
+    expect(extractCommand('ntwigg@mac dormouse % ', zsh)).toBeNull();
   });
 
   it('returns null when the line lacks enough terminators to be this prompt', () => {

--- a/standalone/src-tauri/build.rs
+++ b/standalone/src-tauri/build.rs
@@ -7,7 +7,7 @@ use std::{
 };
 
 fn main() {
-    println!("cargo:rerun-if-env-changed=MOUSETERM_NODE_BINARY");
+    println!("cargo:rerun-if-env-changed=DORMOUSE_NODE_BINARY");
     println!("cargo:rerun-if-env-changed=NODE_BINARY");
     println!("cargo:rerun-if-env-changed=PATH");
 
@@ -137,7 +137,7 @@ fn reject_macos_dynamic_node(node_source: &Path) -> Result<(), Box<dyn Error>> {
     let deps = String::from_utf8_lossy(&output.stdout);
     if deps.contains("@rpath/libnode.") {
         return Err(format!(
-            "{} depends on @rpath/libnode*.dylib and cannot be copied as a self-contained Tauri sidecar. Use a standalone Node.js binary, or set MOUSETERM_NODE_BINARY to one.",
+            "{} depends on @rpath/libnode*.dylib and cannot be copied as a self-contained Tauri sidecar. Use a standalone Node.js binary, or set DORMOUSE_NODE_BINARY to one.",
             node_source.display()
         )
         .into());
@@ -196,7 +196,7 @@ fn verify_node_version(
 ) -> Result<(), Box<dyn Error>> {
     if host != target {
         // Can't execute a foreign-arch binary; the operator supplied it via
-        // MOUSETERM_NODE_BINARY and is responsible for matching the pin.
+        // DORMOUSE_NODE_BINARY and is responsible for matching the pin.
         println!(
             "cargo:warning=skipping Node.js version check when cross-compiling to {target}; \
              ensure the bundled runtime is v{pinned}"
@@ -227,14 +227,14 @@ fn verify_node_version(
 }
 
 fn resolve_node_binary(host: &str, target: &str) -> Result<PathBuf, Box<dyn Error>> {
-    if let Some(path) = env::var_os("MOUSETERM_NODE_BINARY").or_else(|| env::var_os("NODE_BINARY"))
+    if let Some(path) = env::var_os("DORMOUSE_NODE_BINARY").or_else(|| env::var_os("NODE_BINARY"))
     {
         return Ok(PathBuf::from(path));
     }
 
     if host != target {
         return Err(format!(
-            "cross-compiling the standalone app requires MOUSETERM_NODE_BINARY for target {target}"
+            "cross-compiling the standalone app requires DORMOUSE_NODE_BINARY for target {target}"
         )
         .into());
     }

--- a/vscode-ext/src/webview-html.ts
+++ b/vscode-ext/src/webview-html.ts
@@ -53,7 +53,7 @@ export function getWebviewHtml(
   // get a duplicate nonce attribute from the regex above.
   html = html.replace(
     '</head>',
-    `    <script nonce="${nonce}">globalThis.__MOUSETERM_HOST_STATE__ = ${serializeForInlineScript(initialState)};\nglobalThis.__MOUSETERM_SELECTED_SHELL__ = ${serializeForInlineScript(selectedShell ?? null)};</script>\n  </head>`,
+    `    <script nonce="${nonce}">globalThis.__DORMOUSE_HOST_STATE__ = ${serializeForInlineScript(initialState)};\nglobalThis.__DORMOUSE_SELECTED_SHELL__ = ${serializeForInlineScript(selectedShell ?? null)};</script>\n  </head>`,
   );
 
   return html;


### PR DESCRIPTION
## What

Renames the remaining **live** `mouseterm` identifiers left over from the MouseTerm → Dormouse rebrand.

| File | Change |
|------|--------|
| `standalone/src-tauri/build.rs` | `MOUSETERM_NODE_BINARY` → `DORMOUSE_NODE_BINARY` (env var, all refs) |
| `lib/src/lib/platform/vscode-adapter.ts` | `__MOUSETERM_HOST_STATE__` / `__MOUSETERM_SELECTED_SHELL__` → `__DORMOUSE_*` |
| `vscode-ext/src/webview-html.ts` | matching `__DORMOUSE_*` globals (paired host↔webview contract) |
| `lib/src/lib/terminal-prompt-shape.test.ts` | `mouseterm` sample prompts → `dormouse` |

## Deliberately left unchanged

- `CHANGELOG.md` — the historical rebrand entry and the old `mouseterm.log` filename from prior releases (a factual record).
- `vscode-ext/package.json` + `docs/specs/vscode.md` — the `code --uninstall-extension diffplug.mouseterm` line that intentionally removes the **legacy** extension on dogfood.

## Verification

- `terminal-prompt-shape` tests pass (11/11)
- `pnpm run build:vscode` typechecks clean (covers both the lib adapter and the vscode-ext webview, confirming the paired global rename is consistent)
- `build.rs` env-var rename is exercised by the standalone build

🤖 Generated with [Claude Code](https://claude.com/claude-code)